### PR TITLE
feat: add vault-client library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +102,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
@@ -181,6 +196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +245,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -314,6 +352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +374,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -433,6 +490,37 @@ checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -612,6 +700,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -803,6 +901,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1016,6 +1138,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,10 +1219,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1112,6 +1259,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1300,12 @@ name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1310,6 +1488,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1716,6 +1905,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2175,6 +2375,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2446,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vault-client"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "directories",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "vaultrs",
+ "webbrowser",
+ "wiremock",
+]
+
+[[package]]
 name = "vaultrs"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2483,12 @@ dependencies = [
  "tracing",
  "url",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2373,6 +2604,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f1243ef785213e3a32fa0396093424a3a6ea566f9948497e5a2309261a4c97"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2644,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2445,6 +2727,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2483,6 +2774,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2526,6 +2832,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2544,6 +2856,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2559,6 +2877,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2592,6 +2916,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2607,6 +2937,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2628,6 +2964,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2643,6 +2985,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "vaultrs",
+ "vault-client",
  "wiremock",
 ]
 
@@ -2449,6 +2449,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 name = "vault-client"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "directories",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ resolver = "2"
 members = [
     "lib/struct-log",
     "lib/runtime-settings",
+    "lib/vault-client",
     "example"
 ]

--- a/docs/plans/2026-01-17-runtime-settings-design.md
+++ b/docs/plans/2026-01-17-runtime-settings-design.md
@@ -1,6 +1,6 @@
 # Runtime Settings — Rust Implementation Design
 
-Полная реализация аналога Python cian-settings на Rust.
+Runtime settings библиотека на Rust.
 
 ## Требования
 

--- a/docs/plans/2026-01-17-runtime-settings-implementation.md
+++ b/docs/plans/2026-01-17-runtime-settings-implementation.md
@@ -2,7 +2,7 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Rewrite runtime-settings library with full Python cian-settings parity (except Consul and FakeSettings).
+**Goal:** Rewrite runtime-settings library with full feature parity (except Consul and FakeSettings).
 
 **Architecture:** Provider-based settings loading (env, file, MCS) with 12-filter system (static + dynamic), Vault integration for secrets, watchers for change notifications, and thread-local/task-local scoped contexts.
 
@@ -996,9 +996,9 @@ mod tests {
     fn test_email_filter_match() {
         let filter = EmailFilter;
         let mut headers = HashMap::new();
-        headers.insert("x-real-email".to_string(), "user@cian.ru".to_string());
+        headers.insert("x-real-email".to_string(), "user@example.com".to_string());
         let ctx = make_ctx_with_request("/", headers);
-        assert_eq!(filter.check(".*@cian\\.ru", &ctx), FilterResult::Match);
+        assert_eq!(filter.check(".*@example\\.com", &ctx), FilterResult::Match);
     }
 
     #[test]
@@ -2031,7 +2031,7 @@ use crate::error::SettingsError;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_MCS_BASE_URL: &str = "http://master.runtime-settings.dev3.cian.ru";
+const DEFAULT_MCS_BASE_URL: &str = "http://localhost:8080";
 
 #[derive(Debug, Serialize)]
 struct McsRequest {
@@ -3224,7 +3224,7 @@ impl RuntimeSettingsBuilder {
         if self.mcs_enabled {
             let base_url = self.mcs_base_url.unwrap_or_else(|| {
                 std::env::var("RUNTIME_SETTINGS_BASE_URL")
-                    .unwrap_or_else(|_| "http://master.runtime-settings.dev3.cian.ru".to_string())
+                    .unwrap_or_else(|_| "http://localhost:8080".to_string())
             });
             providers.push(Box::new(McsProvider::new(
                 base_url,

--- a/docs/plans/2026-01-18-sync-secrets-loading.md
+++ b/docs/plans/2026-01-18-sync-secrets-loading.md
@@ -25,7 +25,7 @@
 Python использует **синхронный HTTP клиент** для Vault:
 
 ```python
-# cian_settings/_secrets/_secrets_service.py:36
+# Python secrets service example
 def get_secret(self, path: str) -> 'Secret':
     if path in self._secrets:
         return self._secrets[path]  # Кэш

--- a/docs/plans/2026-01-19-vault-client-design.md
+++ b/docs/plans/2026-01-19-vault-client-design.md
@@ -1,6 +1,6 @@
 # vault-client Library Design
 
-Rust-аналог Python библиотеки `cian-vault` для работы с HashiCorp Vault.
+Rust библиотека для работы с HashiCorp Vault.
 
 ## Overview
 

--- a/docs/plans/2026-01-19-vault-client-design.md
+++ b/docs/plans/2026-01-19-vault-client-design.md
@@ -1,0 +1,239 @@
+# vault-client Library Design
+
+Rust-аналог Python библиотеки `cian-vault` для работы с HashiCorp Vault.
+
+## Overview
+
+Библиотека `vault-client` предоставляет async API для работы с Vault с автоматическим определением окружения и методов аутентификации. Используется внутри `runtime-settings` вместо прямого использования `vaultrs`.
+
+## File Structure
+
+```
+lib/vault-client/
+├── Cargo.toml
+└── src/
+    ├── lib.rs              # pub use, публичный API
+    ├── client.rs           # VaultClient, VaultClientBuilder
+    ├── auth/
+    │   ├── mod.rs          # AuthMethod trait, TokenManager
+    │   ├── token.rs        # StaticTokenAuth
+    │   ├── kubernetes.rs   # KubernetesAuth
+    │   └── oidc.rs         # OidcAuth + browser + callback server
+    ├── kv.rs               # kv_read, kv_metadata реализация
+    ├── models.rs           # KvData, KvMetadata, KvVersion
+    ├── error.rs            # VaultError enum
+    └── cache.rs            # OidcTokenCache (disk)
+```
+
+## Public API
+
+### VaultClient
+
+```rust
+pub struct VaultClient { /* ... */ }
+
+impl VaultClient {
+    /// Автоматически определяет окружение и метод аутентификации:
+    /// 1. Если есть VAULT_TOKEN → static token
+    /// 2. Если есть KUBERNETES_SERVICE_HOST → K8s auth
+    /// 3. Иначе → OIDC (локальная разработка)
+    pub async fn from_env() -> Result<Self, VaultError>;
+
+    /// Builder для кастомной конфигурации
+    pub fn builder() -> VaultClientBuilder;
+
+    /// Получить KV v2 секрет
+    pub async fn kv_read(&self, mount: &str, path: &str) -> Result<KvData, VaultError>;
+
+    /// Получить метаданные секрета (версии, timestamps)
+    pub async fn kv_metadata(&self, mount: &str, path: &str) -> Result<KvMetadata, VaultError>;
+
+    /// Низкоуровневый HTTP запрос к Vault API
+    pub async fn request<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&impl Serialize>,
+    ) -> Result<T, VaultError>;
+}
+```
+
+### VaultClientBuilder
+
+```rust
+pub struct VaultClientBuilder { /* ... */ }
+
+impl VaultClientBuilder {
+    pub fn base_url(self, url: impl Into<String>) -> Self;
+    pub fn token(self, token: impl Into<String>) -> Self;
+    pub fn k8s_auth_method(self, method: impl Into<String>) -> Self;
+    pub fn oidc_auth_method(self, method: impl Into<String>) -> Self;
+    pub fn role(self, role: impl Into<String>) -> Self;
+    pub fn application_name(self, name: impl Into<String>) -> Self;
+
+    /// Минимальная длительность токена для renewal (default: 300 сек)
+    pub fn renewable_token_min_duration(self, duration: Duration) -> Self;
+
+    /// Интервал повтора при ошибках renewal (default: 10 сек)
+    pub fn retry_interval(self, duration: Duration) -> Self;
+
+    pub async fn build(self) -> Result<VaultClient, VaultError>;
+}
+```
+
+### Data Models
+
+```rust
+#[derive(Debug, Clone)]
+pub struct KvData {
+    pub data: HashMap<String, serde_json::Value>,
+    pub metadata: KvVersion,
+}
+
+#[derive(Debug, Clone)]
+pub struct KvVersion {
+    pub version: u64,
+    pub created_time: DateTime<Utc>,
+    pub deletion_time: Option<DateTime<Utc>>,
+    pub destroyed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct KvMetadata {
+    pub created_time: DateTime<Utc>,
+    pub custom_metadata: Option<HashMap<String, String>>,
+    pub versions: Vec<KvVersion>,
+}
+```
+
+### Errors
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum VaultError {
+    #[error("Vault not detected: VAULT_ADDR not set")]
+    VaultNotDetected,
+
+    #[error("Secret not found: {path}")]
+    SecretNotFound { path: String },
+
+    #[error("Vault client error ({status}): {message}")]
+    ClientError {
+        status: u16,
+        message: String,
+        response_data: Option<serde_json::Value>,
+    },
+
+    #[error("Vault request error: {0}")]
+    RequestError(String),
+
+    #[error("Authentication failed: {0}")]
+    AuthError(String),
+
+    #[error("OIDC authentication failed: {0}")]
+    OidcError(String),
+
+    #[error("Kubernetes auth failed: {0}")]
+    KubernetesError(String),
+}
+```
+
+## Environment Variables
+
+Читаются автоматически в `from_env()`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VAULT_ADDR` | — | Адрес Vault сервера (обязателен) |
+| `VAULT_TOKEN` | — | Статический токен (приоритет над auth methods) |
+| `VAULT_AUTH_METHOD` | `"kubernetes"` | Название K8s auth method |
+| `VAULT_ROLE_ID` | `"app"` | Роль для K8s/OIDC |
+| `KUBERNETES_SERVICE_HOST` | — | Детект K8s окружения |
+| `K8S_JWT_TOKEN_PATH` | `/var/run/secrets/kubernetes.io/serviceaccount/token` | Путь к service account token |
+
+## Authentication
+
+### Priority
+
+1. **Static Token** — если есть `VAULT_TOKEN`
+2. **Kubernetes Auth** — если есть `KUBERNETES_SERVICE_HOST`
+3. **OIDC** — fallback для локальной разработки
+
+### Token Management
+
+- Background tokio task для auto-renewal
+- Renewal при достижении 75% от lease_duration
+- При 4xx ошибке renewal — re-authenticate
+- При 5xx ошибке — retry через `retry_interval` (default: 10 сек)
+- Минимальная длительность для renewal: 300 сек
+
+### OIDC Flow
+
+1. Запрос auth URL у Vault (`/v1/auth/{method}/oidc/auth_url`)
+2. Открытие браузера через `webbrowser::open()`
+3. Локальный HTTP сервер на `localhost:8250` для callback
+4. Получение токена через callback endpoint
+
+### OIDC Disk Cache
+
+- Путь: `~/.cache/vault-client/` (через `directories` crate)
+- Ключ кеша: SHA256 от `vault_addr + auth_method + role`
+- Переиспользуем если токен валиден ещё минимум 1 час
+
+## Integration with runtime-settings
+
+### Changes
+
+1. Убираем прямую зависимость от `vaultrs`
+2. `VaultClient` передаётся в `RuntimeSettingsBuilder`
+
+```rust
+let vault = VaultClient::from_env().await?;
+
+let settings = RuntimeSettings::builder()
+    .application("my-service")
+    .vault_client(vault)
+    .build()
+    .await?;
+```
+
+### RuntimeSettingsBuilder
+
+```rust
+impl RuntimeSettingsBuilder {
+    pub fn vault_client(self, client: VaultClient) -> Self;
+}
+```
+
+### SecretsService
+
+```rust
+pub struct SecretsService {
+    client: Option<VaultClient>,  // передан извне
+    cache: RwLock<HashMap<String, CachedSecret>>,
+    version: AtomicU64,
+}
+
+impl SecretsService {
+    pub fn new(client: VaultClient) -> Self;
+    pub fn without_vault() -> Self;
+}
+```
+
+Кеширование секретов и `resolve_secrets()` остаются в runtime-settings.
+
+## Dependencies
+
+```toml
+[dependencies]
+vaultrs = "0.7"
+tokio = { version = "1", features = ["sync", "time", "rt"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+chrono = { version = "0.4", features = ["serde"] }
+directories = "5"
+sha2 = "0.10"
+webbrowser = "1"
+tracing = "0.1"
+```

--- a/docs/plans/2026-01-19-vault-client-implementation.md
+++ b/docs/plans/2026-01-19-vault-client-implementation.md
@@ -1,0 +1,2044 @@
+# vault-client Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a Rust library analogous to Python cian-vault with auto-detection of authentication method and background token renewal.
+
+**Architecture:** VaultClient wraps vaultrs internally, adding TokenManager for automatic authentication and renewal. Auth methods (Token, K8s, OIDC) implement a common trait. Background tokio task handles token refresh at 75% TTL.
+
+**Tech Stack:** vaultrs 0.7, tokio, serde, thiserror, chrono, directories, sha2, webbrowser, tracing
+
+---
+
+## Task 1: Create library scaffold
+
+**Files:**
+- Create: `lib/vault-client/Cargo.toml`
+- Create: `lib/vault-client/src/lib.rs`
+- Modify: `Cargo.toml` (workspace)
+
+**Step 1: Create Cargo.toml**
+
+```toml
+[package]
+name = "vault-client"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+vaultrs = "0.7"
+tokio = { version = "1", features = ["sync", "time", "rt", "net"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+chrono = { version = "0.4", features = ["serde"] }
+directories = "5"
+sha2 = "0.10"
+webbrowser = "1"
+tracing = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+wiremock = "0.6"
+tempfile = "3"
+```
+
+**Step 2: Create lib.rs stub**
+
+```rust
+//! vault-client - Rust client for HashiCorp Vault
+//!
+//! Auto-detects authentication method:
+//! 1. VAULT_TOKEN → static token
+//! 2. KUBERNETES_SERVICE_HOST → K8s auth
+//! 3. Otherwise → OIDC (local development)
+
+mod error;
+mod models;
+
+pub use error::VaultError;
+pub use models::{KvData, KvMetadata, KvVersion};
+```
+
+**Step 3: Add to workspace**
+
+In root `Cargo.toml`, add `"lib/vault-client"` to members array.
+
+**Step 4: Verify build**
+
+Run: `cargo check -p vault-client`
+Expected: Compilation errors (missing modules) - that's fine for now
+
+**Step 5: Commit**
+
+```bash
+git add lib/vault-client Cargo.toml
+git commit -m "chore(vault-client): add library scaffold"
+```
+
+---
+
+## Task 2: Implement error types
+
+**Files:**
+- Create: `lib/vault-client/src/error.rs`
+- Modify: `lib/vault-client/src/lib.rs`
+
+**Step 1: Write error.rs**
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VaultError {
+    #[error("Vault not detected: VAULT_ADDR not set")]
+    VaultNotDetected,
+
+    #[error("Secret not found: {path}")]
+    SecretNotFound { path: String },
+
+    #[error("Vault client error ({status}): {message}")]
+    ClientError {
+        status: u16,
+        message: String,
+        response_data: Option<serde_json::Value>,
+    },
+
+    #[error("Vault request error: {0}")]
+    RequestError(String),
+
+    #[error("Authentication failed: {0}")]
+    AuthError(String),
+
+    #[error("OIDC authentication failed: {0}")]
+    OidcError(String),
+
+    #[error("Kubernetes auth failed: {0}")]
+    KubernetesError(String),
+
+    #[error("Token expired and renewal failed")]
+    TokenExpired,
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+```
+
+**Step 2: Update lib.rs**
+
+```rust
+mod error;
+mod models;
+
+pub use error::VaultError;
+```
+
+**Step 3: Verify build**
+
+Run: `cargo check -p vault-client`
+Expected: Error about missing models module
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/error.rs lib/vault-client/src/lib.rs
+git commit -m "feat(vault-client): add error types"
+```
+
+---
+
+## Task 3: Implement data models
+
+**Files:**
+- Create: `lib/vault-client/src/models.rs`
+- Modify: `lib/vault-client/src/lib.rs`
+
+**Step 1: Write models.rs**
+
+```rust
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// KV v2 secret data with version metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvData {
+    pub data: HashMap<String, serde_json::Value>,
+    pub metadata: KvVersion,
+}
+
+/// Version information for a secret
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvVersion {
+    pub version: u64,
+    pub created_time: DateTime<Utc>,
+    #[serde(default)]
+    pub deletion_time: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub destroyed: bool,
+}
+
+/// Full metadata for a secret including all versions
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvMetadata {
+    pub created_time: DateTime<Utc>,
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String, String>>,
+    pub versions: Vec<KvVersion>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kv_data_deserialize() {
+        let json = r#"{
+            "data": {"username": "admin", "password": "secret"},
+            "metadata": {
+                "version": 1,
+                "created_time": "2024-01-01T00:00:00Z",
+                "destroyed": false
+            }
+        }"#;
+        let data: KvData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.metadata.version, 1);
+        assert_eq!(data.data.get("username").unwrap(), "admin");
+    }
+
+    #[test]
+    fn test_kv_version_optional_fields() {
+        let json = r#"{
+            "version": 2,
+            "created_time": "2024-01-01T00:00:00Z"
+        }"#;
+        let version: KvVersion = serde_json::from_str(json).unwrap();
+        assert_eq!(version.version, 2);
+        assert!(version.deletion_time.is_none());
+        assert!(!version.destroyed);
+    }
+}
+```
+
+**Step 2: Update lib.rs exports**
+
+```rust
+mod error;
+mod models;
+
+pub use error::VaultError;
+pub use models::{KvData, KvMetadata, KvVersion};
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 2 tests pass
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/models.rs lib/vault-client/src/lib.rs
+git commit -m "feat(vault-client): add data models"
+```
+
+---
+
+## Task 4: Implement auth module scaffold and TokenInfo
+
+**Files:**
+- Create: `lib/vault-client/src/auth/mod.rs`
+- Create: `lib/vault-client/src/auth/token_info.rs`
+- Modify: `lib/vault-client/src/lib.rs`
+
+**Step 1: Create auth/token_info.rs**
+
+```rust
+use std::time::{Duration, Instant};
+
+/// Token information from authentication
+#[derive(Debug, Clone)]
+pub struct TokenInfo {
+    pub token: String,
+    pub lease_duration: Duration,
+    pub renewable: bool,
+    pub obtained_at: Instant,
+}
+
+impl TokenInfo {
+    pub fn new(token: String, lease_duration: Duration, renewable: bool) -> Self {
+        Self {
+            token,
+            lease_duration,
+            renewable,
+            obtained_at: Instant::now(),
+        }
+    }
+
+    /// Static token (never expires)
+    pub fn static_token(token: String) -> Self {
+        Self {
+            token,
+            lease_duration: Duration::ZERO,
+            renewable: false,
+            obtained_at: Instant::now(),
+        }
+    }
+
+    /// Check if token needs refresh (at threshold % of lease)
+    pub fn needs_refresh(&self, threshold: f64) -> bool {
+        if self.lease_duration.is_zero() {
+            return false; // Static token
+        }
+        let elapsed = self.obtained_at.elapsed();
+        let threshold_duration = Duration::from_secs_f64(self.lease_duration.as_secs_f64() * threshold);
+        elapsed >= threshold_duration
+    }
+
+    /// Check if token is expired
+    pub fn is_expired(&self) -> bool {
+        if self.lease_duration.is_zero() {
+            return false;
+        }
+        self.obtained_at.elapsed() >= self.lease_duration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_static_token_never_expires() {
+        let token = TokenInfo::static_token("test".to_string());
+        assert!(!token.needs_refresh(0.75));
+        assert!(!token.is_expired());
+    }
+
+    #[test]
+    fn test_token_needs_refresh_at_threshold() {
+        let mut token = TokenInfo::new("test".to_string(), Duration::from_secs(100), true);
+        // Simulate time passing
+        token.obtained_at = Instant::now() - Duration::from_secs(80);
+        assert!(token.needs_refresh(0.75));
+    }
+
+    #[test]
+    fn test_token_not_expired_before_lease() {
+        let mut token = TokenInfo::new("test".to_string(), Duration::from_secs(100), true);
+        token.obtained_at = Instant::now() - Duration::from_secs(50);
+        assert!(!token.is_expired());
+    }
+}
+```
+
+**Step 2: Create auth/mod.rs**
+
+```rust
+mod token_info;
+
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+/// Trait for authentication methods
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    /// Perform initial authentication
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+
+    /// Whether this method supports token renewal via renew-self
+    fn supports_renewal(&self) -> bool;
+}
+```
+
+**Step 3: Update lib.rs**
+
+```rust
+mod auth;
+mod error;
+mod models;
+
+pub use error::VaultError;
+pub use models::{KvData, KvMetadata, KvVersion};
+
+// Re-export for advanced usage
+pub use auth::TokenInfo;
+```
+
+**Step 4: Add async-trait dependency**
+
+Add to `lib/vault-client/Cargo.toml`:
+```toml
+async-trait = "0.1"
+```
+
+**Step 5: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 5 tests pass (2 models + 3 token_info)
+
+**Step 6: Commit**
+
+```bash
+git add lib/vault-client/src/auth lib/vault-client/Cargo.toml lib/vault-client/src/lib.rs
+git commit -m "feat(vault-client): add auth module with TokenInfo"
+```
+
+---
+
+## Task 5: Implement static token auth
+
+**Files:**
+- Create: `lib/vault-client/src/auth/token.rs`
+- Modify: `lib/vault-client/src/auth/mod.rs`
+
+**Step 1: Create auth/token.rs**
+
+```rust
+use super::{AuthMethod, TokenInfo};
+use crate::VaultError;
+use async_trait::async_trait;
+
+/// Static token authentication
+pub struct StaticTokenAuth {
+    token: String,
+}
+
+impl StaticTokenAuth {
+    pub fn new(token: String) -> Self {
+        Self { token }
+    }
+}
+
+#[async_trait]
+impl AuthMethod for StaticTokenAuth {
+    async fn authenticate(&self, _base_url: &str) -> Result<TokenInfo, VaultError> {
+        Ok(TokenInfo::static_token(self.token.clone()))
+    }
+
+    fn supports_renewal(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_static_token_auth() {
+        let auth = StaticTokenAuth::new("my-token".to_string());
+        let token_info = auth.authenticate("http://vault:8200").await.unwrap();
+        assert_eq!(token_info.token, "my-token");
+        assert!(!auth.supports_renewal());
+    }
+}
+```
+
+**Step 2: Update auth/mod.rs**
+
+```rust
+mod token;
+mod token_info;
+
+pub use token::StaticTokenAuth;
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+    fn supports_renewal(&self) -> bool;
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 6 tests pass
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/auth/token.rs lib/vault-client/src/auth/mod.rs
+git commit -m "feat(vault-client): add static token auth"
+```
+
+---
+
+## Task 6: Implement Kubernetes auth
+
+**Files:**
+- Create: `lib/vault-client/src/auth/kubernetes.rs`
+- Modify: `lib/vault-client/src/auth/mod.rs`
+
+**Step 1: Create auth/kubernetes.rs**
+
+```rust
+use super::{AuthMethod, TokenInfo};
+use crate::VaultError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const DEFAULT_JWT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+/// Kubernetes authentication
+pub struct KubernetesAuth {
+    pub auth_method: String,
+    pub role: String,
+    pub jwt_path: String,
+}
+
+impl KubernetesAuth {
+    pub fn new(auth_method: String, role: String) -> Self {
+        Self {
+            auth_method,
+            role,
+            jwt_path: DEFAULT_JWT_PATH.to_string(),
+        }
+    }
+
+    pub fn with_jwt_path(mut self, path: String) -> Self {
+        self.jwt_path = path;
+        self
+    }
+
+    fn read_jwt(&self) -> Result<String, VaultError> {
+        std::fs::read_to_string(&self.jwt_path)
+            .map(|s| s.trim().to_string())
+            .map_err(|e| VaultError::KubernetesError(format!("Failed to read JWT from {}: {}", self.jwt_path, e)))
+    }
+}
+
+#[derive(Serialize)]
+struct LoginRequest {
+    jwt: String,
+    role: String,
+}
+
+#[derive(Deserialize)]
+struct LoginResponse {
+    auth: AuthData,
+}
+
+#[derive(Deserialize)]
+struct AuthData {
+    client_token: String,
+    lease_duration: u64,
+    renewable: bool,
+}
+
+#[async_trait]
+impl AuthMethod for KubernetesAuth {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError> {
+        let jwt = self.read_jwt()?;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/auth/{}/login", base_url, self.auth_method);
+
+        let response = client
+            .post(&url)
+            .json(&LoginRequest {
+                jwt,
+                role: self.role.clone(),
+            })
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        let login: LoginResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::AuthError(format!("Invalid response: {}", e)))?;
+
+        Ok(TokenInfo::new(
+            login.auth.client_token,
+            Duration::from_secs(login.auth.lease_duration),
+            login.auth.renewable,
+        ))
+    }
+
+    fn supports_renewal(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_jwt_from_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "my-jwt-token").unwrap();
+
+        let auth = KubernetesAuth::new("kubernetes".to_string(), "app".to_string())
+            .with_jwt_path(file.path().to_str().unwrap().to_string());
+
+        let jwt = auth.read_jwt().unwrap();
+        assert_eq!(jwt, "my-jwt-token");
+    }
+
+    #[test]
+    fn test_read_jwt_missing_file() {
+        let auth = KubernetesAuth::new("kubernetes".to_string(), "app".to_string())
+            .with_jwt_path("/nonexistent/path".to_string());
+
+        let result = auth.read_jwt();
+        assert!(matches!(result, Err(VaultError::KubernetesError(_))));
+    }
+}
+```
+
+**Step 2: Update auth/mod.rs**
+
+```rust
+mod kubernetes;
+mod token;
+mod token_info;
+
+pub use kubernetes::KubernetesAuth;
+pub use token::StaticTokenAuth;
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+    fn supports_renewal(&self) -> bool;
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 8 tests pass
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/auth/kubernetes.rs lib/vault-client/src/auth/mod.rs
+git commit -m "feat(vault-client): add kubernetes auth"
+```
+
+---
+
+## Task 7: Implement OIDC disk cache
+
+**Files:**
+- Create: `lib/vault-client/src/auth/oidc_cache.rs`
+- Modify: `lib/vault-client/src/auth/mod.rs`
+
+**Step 1: Create auth/oidc_cache.rs**
+
+```rust
+use crate::VaultError;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const MIN_REMAINING_TTL: Duration = Duration::from_secs(3600); // 1 hour
+
+#[derive(Serialize, Deserialize)]
+struct CachedToken {
+    token: String,
+    expires_at: u64, // Unix timestamp
+}
+
+pub struct OidcCache {
+    cache_dir: PathBuf,
+}
+
+impl OidcCache {
+    pub fn new() -> Option<Self> {
+        directories::ProjectDirs::from("", "", "vault-client")
+            .map(|dirs| Self {
+                cache_dir: dirs.cache_dir().to_path_buf(),
+            })
+    }
+
+    fn cache_key(vault_addr: &str, auth_method: &str, role: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(vault_addr);
+        hasher.update(auth_method);
+        hasher.update(role);
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn cache_path(&self, vault_addr: &str, auth_method: &str, role: &str) -> PathBuf {
+        let key = Self::cache_key(vault_addr, auth_method, role);
+        self.cache_dir.join(format!("{}.json", key))
+    }
+
+    /// Get cached token if valid for at least MIN_REMAINING_TTL
+    pub fn get(&self, vault_addr: &str, auth_method: &str, role: &str) -> Option<String> {
+        let path = self.cache_path(vault_addr, auth_method, role);
+        let content = std::fs::read_to_string(&path).ok()?;
+        let cached: CachedToken = serde_json::from_str(&content).ok()?;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let remaining = cached.expires_at.saturating_sub(now);
+        if remaining >= MIN_REMAINING_TTL.as_secs() {
+            Some(cached.token)
+        } else {
+            None
+        }
+    }
+
+    /// Store token with expiration
+    pub fn set(
+        &self,
+        vault_addr: &str,
+        auth_method: &str,
+        role: &str,
+        token: &str,
+        ttl: Duration,
+    ) -> Result<(), VaultError> {
+        std::fs::create_dir_all(&self.cache_dir)?;
+
+        let expires_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + ttl.as_secs();
+
+        let cached = CachedToken {
+            token: token.to_string(),
+            expires_at,
+        };
+
+        let path = self.cache_path(vault_addr, auth_method, role);
+        let content = serde_json::to_string(&cached)?;
+        std::fs::write(&path, content)?;
+
+        Ok(())
+    }
+
+    /// Clear cached token
+    pub fn clear(&self, vault_addr: &str, auth_method: &str, role: &str) {
+        let path = self.cache_path(vault_addr, auth_method, role);
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cache_with_temp_dir() -> (OidcCache, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let cache = OidcCache {
+            cache_dir: dir.path().to_path_buf(),
+        };
+        (cache, dir)
+    }
+
+    #[test]
+    fn test_cache_key_is_deterministic() {
+        let key1 = OidcCache::cache_key("http://vault:8200", "oidc", "dev");
+        let key2 = OidcCache::cache_key("http://vault:8200", "oidc", "dev");
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_cache_key_differs_for_different_inputs() {
+        let key1 = OidcCache::cache_key("http://vault:8200", "oidc", "dev");
+        let key2 = OidcCache::cache_key("http://vault:8200", "oidc", "prod");
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn test_set_and_get_token() {
+        let (cache, _dir) = cache_with_temp_dir();
+
+        cache
+            .set("http://vault:8200", "oidc", "dev", "my-token", Duration::from_secs(7200))
+            .unwrap();
+
+        let token = cache.get("http://vault:8200", "oidc", "dev");
+        assert_eq!(token, Some("my-token".to_string()));
+    }
+
+    #[test]
+    fn test_expired_token_not_returned() {
+        let (cache, _dir) = cache_with_temp_dir();
+
+        // Set token with 0 TTL (already expired)
+        cache
+            .set("http://vault:8200", "oidc", "dev", "expired", Duration::ZERO)
+            .unwrap();
+
+        let token = cache.get("http://vault:8200", "oidc", "dev");
+        assert!(token.is_none());
+    }
+
+    #[test]
+    fn test_clear_removes_token() {
+        let (cache, _dir) = cache_with_temp_dir();
+
+        cache
+            .set("http://vault:8200", "oidc", "dev", "my-token", Duration::from_secs(7200))
+            .unwrap();
+
+        cache.clear("http://vault:8200", "oidc", "dev");
+
+        let token = cache.get("http://vault:8200", "oidc", "dev");
+        assert!(token.is_none());
+    }
+}
+```
+
+**Step 2: Update auth/mod.rs**
+
+```rust
+mod kubernetes;
+mod oidc_cache;
+mod token;
+mod token_info;
+
+pub use kubernetes::KubernetesAuth;
+pub use oidc_cache::OidcCache;
+pub use token::StaticTokenAuth;
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+    fn supports_renewal(&self) -> bool;
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 13 tests pass
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/auth/oidc_cache.rs lib/vault-client/src/auth/mod.rs
+git commit -m "feat(vault-client): add OIDC token disk cache"
+```
+
+---
+
+## Task 8: Implement OIDC auth
+
+**Files:**
+- Create: `lib/vault-client/src/auth/oidc.rs`
+- Modify: `lib/vault-client/src/auth/mod.rs`
+
+**Step 1: Create auth/oidc.rs**
+
+```rust
+use super::{AuthMethod, OidcCache, TokenInfo};
+use crate::VaultError;
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+const CALLBACK_PORT: u16 = 8250;
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
+
+/// OIDC authentication (for local development)
+pub struct OidcAuth {
+    pub auth_method: String,
+    pub role: String,
+    cache: Option<OidcCache>,
+}
+
+impl OidcAuth {
+    pub fn new(auth_method: String, role: String) -> Self {
+        Self {
+            auth_method,
+            role,
+            cache: OidcCache::new(),
+        }
+    }
+
+    async fn get_auth_url(&self, base_url: &str) -> Result<(String, String), VaultError> {
+        let client = reqwest::Client::new();
+        let url = format!(
+            "{}/v1/auth/{}/oidc/auth_url",
+            base_url, self.auth_method
+        );
+
+        let response = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "role": self.role,
+                "redirect_uri": format!("http://localhost:{}/oidc/callback", CALLBACK_PORT)
+            }))
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(Deserialize)]
+        struct AuthUrlResponse {
+            data: AuthUrlData,
+        }
+        #[derive(Deserialize)]
+        struct AuthUrlData {
+            auth_url: String,
+            state: String,
+        }
+
+        let resp: AuthUrlResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::OidcError(format!("Invalid auth_url response: {}", e)))?;
+
+        Ok((resp.data.auth_url, resp.data.state))
+    }
+
+    async fn wait_for_callback(&self, expected_state: &str) -> Result<(String, String), VaultError> {
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", CALLBACK_PORT))
+            .await
+            .map_err(|e| VaultError::OidcError(format!("Failed to bind callback port: {}", e)))?;
+
+        let result = tokio::time::timeout(CALLBACK_TIMEOUT, async {
+            let (mut stream, _) = listener.accept().await?;
+
+            let mut reader = BufReader::new(&mut stream);
+            let mut request_line = String::new();
+            reader.read_line(&mut request_line).await?;
+
+            // Parse: GET /oidc/callback?state=...&code=... HTTP/1.1
+            let path = request_line
+                .split_whitespace()
+                .nth(1)
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid request"))?;
+
+            let query = path
+                .split('?')
+                .nth(1)
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "No query string"))?;
+
+            let mut state = None;
+            let mut code = None;
+
+            for pair in query.split('&') {
+                if let Some((key, value)) = pair.split_once('=') {
+                    match key {
+                        "state" => state = Some(value.to_string()),
+                        "code" => code = Some(value.to_string()),
+                        _ => {}
+                    }
+                }
+            }
+
+            // Send response
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><body><h1>Authentication successful!</h1><p>You can close this window.</p></body></html>";
+            stream.write_all(response.as_bytes()).await?;
+
+            Ok::<_, std::io::Error>((
+                state.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Missing state"))?,
+                code.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Missing code"))?,
+            ))
+        })
+        .await
+        .map_err(|_| VaultError::OidcError("Callback timeout".to_string()))?
+        .map_err(|e| VaultError::OidcError(format!("Callback error: {}", e)))?;
+
+        let (state, code) = result;
+        if state != expected_state {
+            return Err(VaultError::OidcError("State mismatch".to_string()));
+        }
+
+        Ok((state, code))
+    }
+
+    async fn exchange_code(
+        &self,
+        base_url: &str,
+        state: &str,
+        code: &str,
+    ) -> Result<TokenInfo, VaultError> {
+        let client = reqwest::Client::new();
+        let url = format!(
+            "{}/v1/auth/{}/oidc/callback?state={}&code={}",
+            base_url, self.auth_method, state, code
+        );
+
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(Deserialize)]
+        struct CallbackResponse {
+            auth: AuthData,
+        }
+        #[derive(Deserialize)]
+        struct AuthData {
+            client_token: String,
+            lease_duration: u64,
+            renewable: bool,
+        }
+
+        let resp: CallbackResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::OidcError(format!("Invalid callback response: {}", e)))?;
+
+        Ok(TokenInfo::new(
+            resp.auth.client_token,
+            Duration::from_secs(resp.auth.lease_duration),
+            resp.auth.renewable,
+        ))
+    }
+}
+
+#[async_trait]
+impl AuthMethod for OidcAuth {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError> {
+        // Check cache first
+        if let Some(ref cache) = self.cache {
+            if let Some(token) = cache.get(base_url, &self.auth_method, &self.role) {
+                tracing::debug!("Using cached OIDC token");
+                return Ok(TokenInfo::static_token(token));
+            }
+        }
+
+        // Get auth URL
+        let (auth_url, state) = self.get_auth_url(base_url).await?;
+
+        // Open browser
+        tracing::info!("Opening browser for OIDC authentication...");
+        if webbrowser::open(&auth_url).is_err() {
+            tracing::warn!("Failed to open browser. Please visit: {}", auth_url);
+        }
+
+        // Wait for callback
+        let (state, code) = self.wait_for_callback(&state).await?;
+
+        // Exchange code for token
+        let token_info = self.exchange_code(base_url, &state, &code).await?;
+
+        // Cache token
+        if let Some(ref cache) = self.cache {
+            if let Err(e) = cache.set(
+                base_url,
+                &self.auth_method,
+                &self.role,
+                &token_info.token,
+                token_info.lease_duration,
+            ) {
+                tracing::warn!("Failed to cache OIDC token: {}", e);
+            }
+        }
+
+        Ok(token_info)
+    }
+
+    fn supports_renewal(&self) -> bool {
+        true
+    }
+}
+```
+
+**Step 2: Update auth/mod.rs**
+
+```rust
+mod kubernetes;
+mod oidc;
+mod oidc_cache;
+mod token;
+mod token_info;
+
+pub use kubernetes::KubernetesAuth;
+pub use oidc::OidcAuth;
+pub use oidc_cache::OidcCache;
+pub use token::StaticTokenAuth;
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+    fn supports_renewal(&self) -> bool;
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 13 tests pass (no new tests for OIDC - requires real Vault)
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/auth/oidc.rs lib/vault-client/src/auth/mod.rs
+git commit -m "feat(vault-client): add OIDC auth with browser flow"
+```
+
+---
+
+## Task 9: Implement TokenManager with background renewal
+
+**Files:**
+- Create: `lib/vault-client/src/auth/manager.rs`
+- Modify: `lib/vault-client/src/auth/mod.rs`
+
+**Step 1: Create auth/manager.rs**
+
+```rust
+use super::{AuthMethod, TokenInfo};
+use crate::VaultError;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+const DEFAULT_REFRESH_THRESHOLD: f64 = 0.75;
+const DEFAULT_MIN_RENEWAL_DURATION: Duration = Duration::from_secs(300);
+const DEFAULT_RETRY_INTERVAL: Duration = Duration::from_secs(10);
+
+pub struct TokenManagerConfig {
+    pub refresh_threshold: f64,
+    pub min_renewal_duration: Duration,
+    pub retry_interval: Duration,
+}
+
+impl Default for TokenManagerConfig {
+    fn default() -> Self {
+        Self {
+            refresh_threshold: DEFAULT_REFRESH_THRESHOLD,
+            min_renewal_duration: DEFAULT_MIN_RENEWAL_DURATION,
+            retry_interval: DEFAULT_RETRY_INTERVAL,
+        }
+    }
+}
+
+pub struct TokenManager {
+    base_url: String,
+    auth_method: Arc<dyn AuthMethod>,
+    token: Arc<RwLock<TokenInfo>>,
+    config: TokenManagerConfig,
+}
+
+impl TokenManager {
+    pub async fn new(
+        base_url: String,
+        auth_method: Arc<dyn AuthMethod>,
+        config: TokenManagerConfig,
+    ) -> Result<Self, VaultError> {
+        let token_info = auth_method.authenticate(&base_url).await?;
+
+        let manager = Self {
+            base_url,
+            auth_method,
+            token: Arc::new(RwLock::new(token_info)),
+            config,
+        };
+
+        manager.start_renewal_task();
+
+        Ok(manager)
+    }
+
+    pub async fn get_token(&self) -> String {
+        self.token.read().await.token.clone()
+    }
+
+    fn start_renewal_task(&self) {
+        let token = Arc::clone(&self.token);
+        let auth_method = Arc::clone(&self.auth_method);
+        let base_url = self.base_url.clone();
+        let config = TokenManagerConfig {
+            refresh_threshold: self.config.refresh_threshold,
+            min_renewal_duration: self.config.min_renewal_duration,
+            retry_interval: self.config.retry_interval,
+        };
+
+        tokio::spawn(async move {
+            loop {
+                let (needs_refresh, sleep_duration) = {
+                    let token_info = token.read().await;
+
+                    if token_info.lease_duration.is_zero() {
+                        // Static token, never refresh
+                        break;
+                    }
+
+                    if token_info.lease_duration < config.min_renewal_duration {
+                        // Token duration too short for renewal
+                        break;
+                    }
+
+                    let needs = token_info.needs_refresh(config.refresh_threshold);
+                    let until_refresh = if needs {
+                        Duration::ZERO
+                    } else {
+                        let threshold_time = Duration::from_secs_f64(
+                            token_info.lease_duration.as_secs_f64() * config.refresh_threshold,
+                        );
+                        threshold_time.saturating_sub(token_info.obtained_at.elapsed())
+                    };
+
+                    (needs, until_refresh)
+                };
+
+                if !needs_refresh {
+                    tokio::time::sleep(sleep_duration).await;
+                    continue;
+                }
+
+                // Try to renew
+                match Self::renew_token(&base_url, &token).await {
+                    Ok(()) => {
+                        tracing::debug!("Token renewed successfully");
+                    }
+                    Err(VaultError::ClientError { status, .. }) if status >= 400 && status < 500 => {
+                        // 4xx error - need to re-authenticate
+                        tracing::info!("Token renewal failed with 4xx, re-authenticating");
+                        match auth_method.authenticate(&base_url).await {
+                            Ok(new_token) => {
+                                let mut t = token.write().await;
+                                *t = new_token;
+                                tracing::debug!("Re-authenticated successfully");
+                            }
+                            Err(e) => {
+                                tracing::error!("Re-authentication failed: {}", e);
+                                tokio::time::sleep(config.retry_interval).await;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // 5xx or network error - retry later
+                        tracing::warn!("Token renewal failed: {}, retrying in {:?}", e, config.retry_interval);
+                        tokio::time::sleep(config.retry_interval).await;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn renew_token(base_url: &str, token: &Arc<RwLock<TokenInfo>>) -> Result<(), VaultError> {
+        let current_token = token.read().await.token.clone();
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/auth/token/renew-self", base_url);
+
+        let response = client
+            .post(&url)
+            .header("X-Vault-Token", &current_token)
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RenewResponse {
+            auth: AuthData,
+        }
+        #[derive(serde::Deserialize)]
+        struct AuthData {
+            client_token: String,
+            lease_duration: u64,
+            renewable: bool,
+        }
+
+        let resp: RenewResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::AuthError(format!("Invalid renewal response: {}", e)))?;
+
+        let mut t = token.write().await;
+        *t = TokenInfo::new(
+            resp.auth.client_token,
+            Duration::from_secs(resp.auth.lease_duration),
+            resp.auth.renewable,
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::StaticTokenAuth;
+
+    #[tokio::test]
+    async fn test_token_manager_with_static_token() {
+        let auth = Arc::new(StaticTokenAuth::new("my-token".to_string()));
+        let manager = TokenManager::new(
+            "http://vault:8200".to_string(),
+            auth,
+            TokenManagerConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(manager.get_token().await, "my-token");
+    }
+}
+```
+
+**Step 2: Update auth/mod.rs**
+
+```rust
+mod kubernetes;
+mod manager;
+mod oidc;
+mod oidc_cache;
+mod token;
+mod token_info;
+
+pub use kubernetes::KubernetesAuth;
+pub use manager::{TokenManager, TokenManagerConfig};
+pub use oidc::OidcAuth;
+pub use oidc_cache::OidcCache;
+pub use token::StaticTokenAuth;
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+    fn supports_renewal(&self) -> bool;
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 14 tests pass
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/auth/manager.rs lib/vault-client/src/auth/mod.rs
+git commit -m "feat(vault-client): add TokenManager with background renewal"
+```
+
+---
+
+## Task 10: Implement VaultClientBuilder and VaultClient
+
+**Files:**
+- Create: `lib/vault-client/src/client.rs`
+- Modify: `lib/vault-client/src/lib.rs`
+
+**Step 1: Create client.rs**
+
+```rust
+use crate::auth::{
+    AuthMethod, KubernetesAuth, OidcAuth, StaticTokenAuth, TokenManager, TokenManagerConfig,
+};
+use crate::error::VaultError;
+use crate::models::{KvData, KvMetadata, KvVersion};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+const DEFAULT_K8S_AUTH_METHOD: &str = "kubernetes";
+const DEFAULT_OIDC_AUTH_METHOD: &str = "oidc";
+const DEFAULT_ROLE: &str = "app";
+
+pub struct VaultClientBuilder {
+    base_url: Option<String>,
+    token: Option<String>,
+    k8s_auth_method: Option<String>,
+    oidc_auth_method: Option<String>,
+    role: Option<String>,
+    application_name: Option<String>,
+    renewable_token_min_duration: Duration,
+    retry_interval: Duration,
+}
+
+impl Default for VaultClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VaultClientBuilder {
+    pub fn new() -> Self {
+        Self {
+            base_url: None,
+            token: None,
+            k8s_auth_method: None,
+            oidc_auth_method: None,
+            role: None,
+            application_name: None,
+            renewable_token_min_duration: Duration::from_secs(300),
+            retry_interval: Duration::from_secs(10),
+        }
+    }
+
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        self.token = Some(token.into());
+        self
+    }
+
+    pub fn k8s_auth_method(mut self, method: impl Into<String>) -> Self {
+        self.k8s_auth_method = Some(method.into());
+        self
+    }
+
+    pub fn oidc_auth_method(mut self, method: impl Into<String>) -> Self {
+        self.oidc_auth_method = Some(method.into());
+        self
+    }
+
+    pub fn role(mut self, role: impl Into<String>) -> Self {
+        self.role = Some(role.into());
+        self
+    }
+
+    pub fn application_name(mut self, name: impl Into<String>) -> Self {
+        self.application_name = Some(name.into());
+        self
+    }
+
+    pub fn renewable_token_min_duration(mut self, duration: Duration) -> Self {
+        self.renewable_token_min_duration = duration;
+        self
+    }
+
+    pub fn retry_interval(mut self, duration: Duration) -> Self {
+        self.retry_interval = duration;
+        self
+    }
+
+    /// Build from environment variables with overrides
+    fn resolve_config(&self) -> Result<ResolvedConfig, VaultError> {
+        let base_url = self
+            .base_url
+            .clone()
+            .or_else(|| std::env::var("VAULT_ADDR").ok())
+            .ok_or(VaultError::VaultNotDetected)?;
+
+        let token = self
+            .token
+            .clone()
+            .or_else(|| std::env::var("VAULT_TOKEN").ok());
+
+        let k8s_auth_method = self
+            .k8s_auth_method
+            .clone()
+            .or_else(|| std::env::var("VAULT_AUTH_METHOD").ok())
+            .unwrap_or_else(|| DEFAULT_K8S_AUTH_METHOD.to_string());
+
+        let oidc_auth_method = self
+            .oidc_auth_method
+            .clone()
+            .unwrap_or_else(|| DEFAULT_OIDC_AUTH_METHOD.to_string());
+
+        let role = self
+            .role
+            .clone()
+            .or_else(|| std::env::var("VAULT_ROLE_ID").ok())
+            .unwrap_or_else(|| DEFAULT_ROLE.to_string());
+
+        let k8s_jwt_path = std::env::var("K8S_JWT_TOKEN_PATH")
+            .unwrap_or_else(|_| "/var/run/secrets/kubernetes.io/serviceaccount/token".to_string());
+
+        let is_kubernetes = std::env::var("KUBERNETES_SERVICE_HOST").is_ok();
+
+        Ok(ResolvedConfig {
+            base_url,
+            token,
+            k8s_auth_method,
+            oidc_auth_method,
+            role,
+            k8s_jwt_path,
+            is_kubernetes,
+            application_name: self.application_name.clone(),
+            renewable_token_min_duration: self.renewable_token_min_duration,
+            retry_interval: self.retry_interval,
+        })
+    }
+
+    pub async fn build(self) -> Result<VaultClient, VaultError> {
+        let config = self.resolve_config()?;
+
+        // Determine auth method
+        let auth_method: Arc<dyn AuthMethod> = if let Some(token) = config.token {
+            // Priority 1: Static token
+            Arc::new(StaticTokenAuth::new(token))
+        } else if config.is_kubernetes {
+            // Priority 2: Kubernetes
+            Arc::new(
+                KubernetesAuth::new(config.k8s_auth_method, config.role)
+                    .with_jwt_path(config.k8s_jwt_path),
+            )
+        } else {
+            // Priority 3: OIDC
+            Arc::new(OidcAuth::new(config.oidc_auth_method, config.role))
+        };
+
+        let token_manager = TokenManager::new(
+            config.base_url.clone(),
+            auth_method,
+            TokenManagerConfig {
+                refresh_threshold: 0.75,
+                min_renewal_duration: config.renewable_token_min_duration,
+                retry_interval: config.retry_interval,
+            },
+        )
+        .await?;
+
+        Ok(VaultClient {
+            base_url: config.base_url,
+            token_manager,
+            application_name: config.application_name,
+        })
+    }
+}
+
+struct ResolvedConfig {
+    base_url: String,
+    token: Option<String>,
+    k8s_auth_method: String,
+    oidc_auth_method: String,
+    role: String,
+    k8s_jwt_path: String,
+    is_kubernetes: bool,
+    application_name: Option<String>,
+    renewable_token_min_duration: Duration,
+    retry_interval: Duration,
+}
+
+pub struct VaultClient {
+    base_url: String,
+    token_manager: TokenManager,
+    application_name: Option<String>,
+}
+
+impl VaultClient {
+    /// Create client from environment variables with auto-detection
+    pub async fn from_env() -> Result<Self, VaultError> {
+        VaultClientBuilder::new().build().await
+    }
+
+    /// Get builder for custom configuration
+    pub fn builder() -> VaultClientBuilder {
+        VaultClientBuilder::new()
+    }
+
+    /// Read KV v2 secret
+    pub async fn kv_read(&self, mount: &str, path: &str) -> Result<KvData, VaultError> {
+        let url = format!("{}/v1/{}/data/{}", self.base_url, mount, path);
+        let token = self.token_manager.get_token().await;
+
+        let client = reqwest::Client::new();
+        let mut request = client.get(&url).header("X-Vault-Token", token);
+
+        if let Some(ref app_name) = self.application_name {
+            request = request.header("User-Agent", app_name);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if response.status().as_u16() == 404 {
+            return Err(VaultError::SecretNotFound {
+                path: path.to_string(),
+            });
+        }
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(serde::Deserialize)]
+        struct KvResponse {
+            data: KvResponseData,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct KvResponseData {
+            data: HashMap<String, serde_json::Value>,
+            metadata: KvVersionResponse,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct KvVersionResponse {
+            version: u64,
+            created_time: String,
+            deletion_time: Option<String>,
+            #[serde(default)]
+            destroyed: bool,
+        }
+
+        let resp: KvResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::RequestError(format!("Invalid response: {}", e)))?;
+
+        Ok(KvData {
+            data: resp.data.data,
+            metadata: KvVersion {
+                version: resp.data.metadata.version,
+                created_time: resp
+                    .data
+                    .metadata
+                    .created_time
+                    .parse()
+                    .map_err(|e| VaultError::RequestError(format!("Invalid timestamp: {}", e)))?,
+                deletion_time: resp
+                    .data
+                    .metadata
+                    .deletion_time
+                    .and_then(|s| s.parse().ok()),
+                destroyed: resp.data.metadata.destroyed,
+            },
+        })
+    }
+
+    /// Read KV v2 secret metadata
+    pub async fn kv_metadata(&self, mount: &str, path: &str) -> Result<KvMetadata, VaultError> {
+        let url = format!("{}/v1/{}/metadata/{}", self.base_url, mount, path);
+        let token = self.token_manager.get_token().await;
+
+        let client = reqwest::Client::new();
+        let mut request = client.get(&url).header("X-Vault-Token", token);
+
+        if let Some(ref app_name) = self.application_name {
+            request = request.header("User-Agent", app_name);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if response.status().as_u16() == 404 {
+            return Err(VaultError::SecretNotFound {
+                path: path.to_string(),
+            });
+        }
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(serde::Deserialize)]
+        struct MetadataResponse {
+            data: MetadataData,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct MetadataData {
+            created_time: String,
+            custom_metadata: Option<HashMap<String, String>>,
+            versions: HashMap<String, VersionInfo>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct VersionInfo {
+            created_time: String,
+            deletion_time: Option<String>,
+            #[serde(default)]
+            destroyed: bool,
+        }
+
+        let resp: MetadataResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::RequestError(format!("Invalid response: {}", e)))?;
+
+        let mut versions: Vec<KvVersion> = resp
+            .data
+            .versions
+            .into_iter()
+            .map(|(version_str, info)| {
+                Ok(KvVersion {
+                    version: version_str
+                        .parse()
+                        .map_err(|_| VaultError::RequestError("Invalid version".to_string()))?,
+                    created_time: info
+                        .created_time
+                        .parse()
+                        .map_err(|e| VaultError::RequestError(format!("Invalid timestamp: {}", e)))?,
+                    deletion_time: info.deletion_time.and_then(|s| s.parse().ok()),
+                    destroyed: info.destroyed,
+                })
+            })
+            .collect::<Result<Vec<_>, VaultError>>()?;
+
+        versions.sort_by_key(|v| v.version);
+
+        Ok(KvMetadata {
+            created_time: resp
+                .data
+                .created_time
+                .parse()
+                .map_err(|e| VaultError::RequestError(format!("Invalid timestamp: {}", e)))?,
+            custom_metadata: resp.data.custom_metadata,
+            versions,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_defaults() {
+        let builder = VaultClientBuilder::new();
+        assert!(builder.base_url.is_none());
+        assert!(builder.token.is_none());
+    }
+
+    #[test]
+    fn test_builder_chain() {
+        let builder = VaultClientBuilder::new()
+            .base_url("http://vault:8200")
+            .token("my-token")
+            .role("admin");
+
+        assert_eq!(builder.base_url, Some("http://vault:8200".to_string()));
+        assert_eq!(builder.token, Some("my-token".to_string()));
+        assert_eq!(builder.role, Some("admin".to_string()));
+    }
+}
+```
+
+**Step 2: Update lib.rs**
+
+```rust
+//! vault-client - Rust client for HashiCorp Vault
+//!
+//! Auto-detects authentication method:
+//! 1. VAULT_TOKEN → static token
+//! 2. KUBERNETES_SERVICE_HOST → K8s auth
+//! 3. Otherwise → OIDC (local development)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vault_client::VaultClient;
+//!
+//! let client = VaultClient::from_env().await?;
+//! let secret = client.kv_read("secret", "my/path").await?;
+//! println!("{:?}", secret.data);
+//! ```
+
+mod auth;
+mod client;
+mod error;
+mod models;
+
+pub use client::{VaultClient, VaultClientBuilder};
+pub use error::VaultError;
+pub use models::{KvData, KvMetadata, KvVersion};
+
+// Re-export for advanced usage
+pub use auth::TokenInfo;
+```
+
+**Step 3: Run tests**
+
+Run: `cargo test -p vault-client`
+Expected: 16 tests pass
+
+**Step 4: Commit**
+
+```bash
+git add lib/vault-client/src/client.rs lib/vault-client/src/lib.rs
+git commit -m "feat(vault-client): add VaultClient and VaultClientBuilder"
+```
+
+---
+
+## Task 11: Integrate vault-client into runtime-settings
+
+**Files:**
+- Modify: `lib/runtime-settings/Cargo.toml`
+- Modify: `lib/runtime-settings/src/settings.rs`
+- Modify: `lib/runtime-settings/src/secrets/mod.rs`
+
+**Step 1: Update runtime-settings Cargo.toml**
+
+Replace `vaultrs` dependency with `vault-client`:
+
+```toml
+# Remove: vaultrs = "0.7"
+# Add:
+vault-client = { path = "../vault-client" }
+```
+
+**Step 2: Update secrets/mod.rs**
+
+Replace vaultrs imports and usage:
+
+```rust
+// Remove:
+// use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
+
+// Add:
+use vault_client::VaultClient;
+
+// Update SecretsService struct:
+pub struct SecretsService {
+    client: Option<VaultClient>,  // Now vault_client::VaultClient
+    cache: RwLock<HashMap<String, CachedSecret>>,
+    refresh_intervals: HashMap<String, Duration>,
+    version: AtomicU64,
+}
+
+// Remove from_env() method - client now passed from outside
+
+impl SecretsService {
+    pub fn new_without_vault() -> Self {
+        Self {
+            client: None,
+            cache: RwLock::new(HashMap::new()),
+            refresh_intervals: Self::load_refresh_intervals(),
+            version: AtomicU64::new(0),
+        }
+    }
+
+    pub fn new(client: VaultClient) -> Self {
+        Self {
+            client: Some(client),
+            cache: RwLock::new(HashMap::new()),
+            refresh_intervals: Self::load_refresh_intervals(),
+            version: AtomicU64::new(0),
+        }
+    }
+
+    // Update get() method to use vault_client API:
+    pub async fn get(&self, path: &str, key: &str) -> Result<serde_json::Value, SettingsError> {
+        let client = self
+            .client
+            .as_ref()
+            .ok_or(SettingsError::SecretWithoutVault)?;
+
+        // Check cache first
+        {
+            let cache = self.cache.read().await;
+            if let Some(cached) = cache.get(path) {
+                if let Some(value) = cached.value.get(key) {
+                    return Ok(value.clone());
+                }
+            }
+        }
+
+        // Fetch from Vault using vault-client
+        let kv_data = client
+            .kv_read("secret", path)
+            .await
+            .map_err(|e| SettingsError::Vault(e.to_string()))?;
+
+        let secret: serde_json::Value = serde_json::to_value(&kv_data.data)
+            .map_err(|e| SettingsError::Vault(e.to_string()))?;
+
+        // Cache it
+        {
+            let mut cache = self.cache.write().await;
+            cache.insert(
+                path.to_string(),
+                CachedSecret {
+                    value: secret.clone(),
+                    lease_id: None,
+                    lease_duration: None,
+                    renewable: false,
+                    fetched_at: Instant::now(),
+                },
+            );
+        }
+
+        secret
+            .get(key)
+            .cloned()
+            .ok_or_else(|| SettingsError::SecretKeyNotFound {
+                path: path.to_string(),
+                key: key.to_string(),
+            })
+    }
+
+    // Update refresh() similarly
+}
+```
+
+**Step 3: Update settings.rs builder**
+
+Add vault_client method to RuntimeSettingsBuilder:
+
+```rust
+use vault_client::VaultClient;
+
+pub struct RuntimeSettingsBuilder {
+    // ... existing fields ...
+    vault_client: Option<VaultClient>,
+}
+
+impl RuntimeSettingsBuilder {
+    pub fn vault_client(mut self, client: VaultClient) -> Self {
+        self.vault_client = Some(client);
+        self
+    }
+
+    pub async fn build(self) -> Result<RuntimeSettings, SettingsError> {
+        // ...
+        let secrets = match self.vault_client {
+            Some(client) => SecretsService::new(client),
+            None => SecretsService::new_without_vault(),
+        };
+        // ...
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p runtime-settings`
+Expected: All existing tests pass
+
+**Step 5: Commit**
+
+```bash
+git add lib/runtime-settings/Cargo.toml lib/runtime-settings/src/secrets/mod.rs lib/runtime-settings/src/settings.rs
+git commit -m "refactor(runtime-settings): use vault-client instead of vaultrs"
+```
+
+---
+
+## Task 12: Update lib.rs exports and documentation
+
+**Files:**
+- Modify: `lib/runtime-settings/src/lib.rs`
+
+**Step 1: Re-export VaultClient**
+
+```rust
+// Add to lib.rs exports:
+pub use vault_client::{VaultClient, VaultClientBuilder};
+```
+
+**Step 2: Run full workspace tests**
+
+Run: `cargo test`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add lib/runtime-settings/src/lib.rs
+git commit -m "feat(runtime-settings): re-export VaultClient"
+```
+
+---
+
+## Summary
+
+After completing all tasks:
+
+1. New `vault-client` library with:
+   - Auto-detection of auth method (Token → K8s → OIDC)
+   - Background token renewal
+   - OIDC disk cache
+   - Full KV v2 support
+
+2. Updated `runtime-settings`:
+   - Uses `vault-client` instead of `vaultrs`
+   - `VaultClient` passed via builder
+   - Re-exports `VaultClient` for convenience
+
+3. Usage:
+   ```rust
+   use runtime_settings::{RuntimeSettings, VaultClient, setup, settings};
+
+   let vault = VaultClient::from_env().await?;
+
+   setup(
+       RuntimeSettings::builder()
+           .application("my-service")
+           .vault_client(vault)
+   ).await?;
+
+   let value: Option<Arc<String>> = settings().get("KEY");
+   ```

--- a/docs/plans/2026-01-19-vault-client-implementation.md
+++ b/docs/plans/2026-01-19-vault-client-implementation.md
@@ -2,7 +2,7 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Create a Rust library analogous to Python cian-vault with auto-detection of authentication method and background token renewal.
+**Goal:** Create a Rust library for HashiCorp Vault with auto-detection of authentication method and background token renewal.
 
 **Architecture:** VaultClient wraps vaultrs internally, adding TokenManager for automatic authentication and renewal. Auth methods (Token, K8s, OIDC) implement a common trait. Background tokio task handles token refresh at 75% TTL.
 

--- a/docs/plans/2026-01-19-vault-full-path-design.md
+++ b/docs/plans/2026-01-19-vault-full-path-design.md
@@ -1,0 +1,71 @@
+# Vault Full Path Support
+
+## Problem
+
+В текущей Rust реализации mount для Vault захардкожен как `"secret"`:
+
+```rust
+// lib/runtime-settings/src/secrets/mod.rs:188
+client.kv_read("secret", path)
+```
+
+В Python реализации путь передается полностью, включая mount:
+
+```python
+# cian_settings/_secrets/_secrets_service.py:36
+response = self._client.request('GET', f'/v1/{path}')
+```
+
+## Solution
+
+Добавить метод `kv_read_raw` в `VaultClient`, который принимает полный путь.
+
+### Новый формат секретов в настройках
+
+```json
+{"$secret": "secret/data/database/creds:password"}
+```
+
+Вместо текущего:
+
+```json
+{"$secret": "database/creds:password"}
+```
+
+## Implementation
+
+### Step 1: Add `kv_read_raw` method to VaultClient
+
+File: `lib/vault-client/src/client.rs`
+
+```rust
+pub async fn kv_read_raw(&self, full_path: &str) -> Result<KvData, VaultError> {
+    let url = format!("{}/v1/{}", self.base_url, full_path);
+    // ... same parsing logic as kv_read
+}
+```
+
+### Step 2: Update SecretsService to use `kv_read_raw`
+
+File: `lib/runtime-settings/src/secrets/mod.rs`
+
+Replace:
+```rust
+client.kv_read("secret", path)
+```
+
+With:
+```rust
+client.kv_read_raw(path)
+```
+
+### Step 3: Update tests
+
+- Update mock responses to use full paths
+- Update test settings to use new format with `secret/data/` prefix
+
+## Files to modify
+
+1. `lib/vault-client/src/client.rs` - add `kv_read_raw` method
+2. `lib/runtime-settings/src/secrets/mod.rs` - use `kv_read_raw` instead of `kv_read`
+3. `lib/runtime-settings/tests/integration_vault.rs` - update test paths

--- a/lib/runtime-settings/Cargo.toml
+++ b/lib/runtime-settings/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 json5 = "1"
 
 # Vault
-vaultrs = "0.7"
+vault-client = { path = "../vault-client" }
 
 # Utilities
 futures = "0.3"

--- a/lib/runtime-settings/README.md
+++ b/lib/runtime-settings/README.md
@@ -103,7 +103,7 @@ async fn main() {
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `RUNTIME_SETTINGS_APPLICATION` | Application name for `setup_from_env()` | `"unknown"` |
-| `RUNTIME_SETTINGS_BASE_URL` | MCS service URL | `http://master.runtime-settings.dev3.cian.ru` |
+| `RUNTIME_SETTINGS_BASE_URL` | MCS service URL | `http://localhost:8080` |
 | `RUNTIME_SETTINGS_FILE_PATH` | Path to settings JSON file | `runtime-settings.json` |
 | `MCS_RUN_ENV` | MCS environment filter value | None |
 | `VAULT_ADDR` | Vault server address | Required for secrets |

--- a/lib/runtime-settings/README.md
+++ b/lib/runtime-settings/README.md
@@ -103,7 +103,7 @@ async fn main() {
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `RUNTIME_SETTINGS_APPLICATION` | Application name for `setup_from_env()` | `"unknown"` |
-| `RUNTIME_SETTINGS_BASE_URL` | MCS service URL | `http://localhost:8080` |
+| `RUNTIME_SETTINGS_BASE_URL` | MCS service URL | Required when MCS enabled |
 | `RUNTIME_SETTINGS_FILE_PATH` | Path to settings JSON file | `runtime-settings.json` |
 | `MCS_RUN_ENV` | MCS environment filter value | None |
 | `VAULT_ADDR` | Vault server address | Required for secrets |

--- a/lib/runtime-settings/README.md
+++ b/lib/runtime-settings/README.md
@@ -135,7 +135,7 @@ Settings are stored as a JSON array. JSON5 format with comments is supported:
   {
     // Setting with secret reference
     "key": "API_SECRET",
-    "value": {"$secret": "secret/api:key"},
+    "value": {"$secret": "secret/data/api:key"},
     "priority": 100
   },
   {
@@ -144,7 +144,7 @@ Settings are stored as a JSON array. JSON5 format with comments is supported:
     "value": {
       "host": "localhost",
       "port": 5432,
-      "password": {"$secret": "database/prod:password"}
+      "password": {"$secret": "secret/data/database/prod:password"}
     },
     "priority": 100
   }
@@ -414,18 +414,18 @@ Vault is automatically configured when these variables are present. If not confi
 
 ### Secret Reference Syntax
 
-Use `{"$secret": "path:key"}` in setting values:
+Use `{"$secret": "full_vault_path:key"}` in setting values:
 
 ```json
 {
   "key": "DB_PASSWORD",
-  "value": {"$secret": "database/prod:password"}
+  "value": {"$secret": "secret/data/database/prod:password"}
 }
 ```
 
-Format: `vault_path:key_in_secret`
+Format: `full_vault_path:key_in_secret`
 
-- `path`: Vault KV v2 path (e.g., `database/prod`)
+- `full_vault_path`: Full Vault KV v2 path including mount and `/data/` (e.g., `secret/data/database/prod`)
 - `key`: Key within the secret data (e.g., `password`)
 
 Secrets can be nested in complex values:
@@ -438,7 +438,7 @@ Secrets can be nested in complex values:
     "port": 5432,
     "credentials": {
       "username": "app",
-      "password": {"$secret": "database/prod:password"}
+      "password": {"$secret": "secret/data/database/prod:password"}
     }
   }
 }

--- a/lib/runtime-settings/src/entities.rs
+++ b/lib/runtime-settings/src/entities.rs
@@ -380,7 +380,7 @@ mod tests {
             filter: HashMap::new(),
             value: serde_json::json!({
                 "host": "localhost",
-                "password": {"$secret": "db/creds:password"}
+                "password": {"$secret": "secret/data/db/creds:password"}
             }),
         };
         let setting = Setting::compile(raw).unwrap();
@@ -412,7 +412,7 @@ mod tests {
             priority: 100,
             filter: HashMap::new(),
             value: serde_json::json!({
-                "password": {"$secret": "db:pass"}
+                "password": {"$secret": "secret/data/db:pass"}
             }),
         };
         let setting = Setting::compile(raw).unwrap();

--- a/lib/runtime-settings/src/error.rs
+++ b/lib/runtime-settings/src/error.rs
@@ -41,4 +41,7 @@ pub enum SettingsError {
 
     #[error("Request timed out")]
     Timeout,
+
+    #[error("Missing required configuration: {0}")]
+    MissingConfig(String),
 }

--- a/lib/runtime-settings/src/filters/dynamic_filters.rs
+++ b/lib/runtime-settings/src/filters/dynamic_filters.rs
@@ -544,9 +544,9 @@ mod tests {
     fn test_email_filter_match() {
         let filter = EmailFilter;
         let mut headers = HashMap::new();
-        headers.insert("x-real-email".to_string(), "user@cian.ru".to_string());
+        headers.insert("x-real-email".to_string(), "user@example.com".to_string());
         let ctx = make_ctx_with_request("/", headers);
-        assert_eq!(filter.check(".*@cian\\.ru", &ctx), FilterResult::Match);
+        assert_eq!(filter.check(".*@example\\.com", &ctx), FilterResult::Match);
     }
 
     #[test]
@@ -730,16 +730,16 @@ mod compiled_dynamic_tests {
     // CompiledEmailFilter tests
     #[test]
     fn test_compiled_email_filter_match() {
-        let filter = CompiledEmailFilter::compile(".*@cian\\.ru").unwrap();
+        let filter = CompiledEmailFilter::compile(".*@example\\.com").unwrap();
         let mut headers = HashMap::new();
-        headers.insert("x-real-email".to_string(), "user@cian.ru".to_string());
+        headers.insert("x-real-email".to_string(), "user@example.com".to_string());
         let ctx = make_ctx_with_request("/", headers);
         assert!(filter.check(&ctx));
     }
 
     #[test]
     fn test_compiled_email_filter_no_match() {
-        let filter = CompiledEmailFilter::compile(".*@cian\\.ru").unwrap();
+        let filter = CompiledEmailFilter::compile(".*@example\\.com").unwrap();
         let mut headers = HashMap::new();
         headers.insert("x-real-email".to_string(), "user@other.com".to_string());
         let ctx = make_ctx_with_request("/", headers);
@@ -748,14 +748,14 @@ mod compiled_dynamic_tests {
 
     #[test]
     fn test_compiled_email_filter_no_request_returns_true() {
-        let filter = CompiledEmailFilter::compile(".*@cian\\.ru").unwrap();
+        let filter = CompiledEmailFilter::compile(".*@example\\.com").unwrap();
         let ctx = DynamicContext::default();
         assert!(filter.check(&ctx));
     }
 
     #[test]
     fn test_compiled_email_filter_no_email_returns_true() {
-        let filter = CompiledEmailFilter::compile(".*@cian\\.ru").unwrap();
+        let filter = CompiledEmailFilter::compile(".*@example\\.com").unwrap();
         let ctx = make_ctx_with_request("/", HashMap::new());
         assert!(filter.check(&ctx));
     }

--- a/lib/runtime-settings/src/lib.rs
+++ b/lib/runtime-settings/src/lib.rs
@@ -21,5 +21,6 @@ pub use scoped::{
 };
 pub use secrets::{resolve_secrets, SecretsService};
 pub use settings::{RuntimeSettings, RuntimeSettingsBuilder};
+pub use vault_client::{VaultClient, VaultClientBuilder};
 pub use setup::{settings, setup, setup_from_env};
 pub use watchers::{Watcher, WatcherId, WatchersService};

--- a/lib/runtime-settings/src/providers/mcs.rs
+++ b/lib/runtime-settings/src/providers/mcs.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use serde::Serialize;
 use uuid::Uuid;
 
-const DEFAULT_MCS_BASE_URL: &str = "http://master.runtime-settings.dev3.cian.ru";
+const DEFAULT_MCS_BASE_URL: &str = "http://localhost:8080";
 
 #[derive(Debug, Serialize)]
 struct McsRequest {

--- a/lib/runtime-settings/src/providers/mcs.rs
+++ b/lib/runtime-settings/src/providers/mcs.rs
@@ -7,8 +7,6 @@ use async_trait::async_trait;
 use serde::Serialize;
 use uuid::Uuid;
 
-const DEFAULT_MCS_BASE_URL: &str = "http://localhost:8080";
-
 #[derive(Debug, Serialize)]
 struct McsRequest {
     runtime: String,
@@ -37,11 +35,12 @@ impl McsProvider {
     }
 
     /// Create from environment variables
-    pub fn from_env(application: String) -> Self {
-        let base_url = std::env::var("RUNTIME_SETTINGS_BASE_URL")
-            .unwrap_or_else(|_| DEFAULT_MCS_BASE_URL.to_string());
+    ///
+    /// Returns None if RUNTIME_SETTINGS_BASE_URL is not set.
+    pub fn from_env(application: String) -> Option<Self> {
+        let base_url = std::env::var("RUNTIME_SETTINGS_BASE_URL").ok()?;
         let mcs_run_env = std::env::var("MCS_RUN_ENV").ok();
-        Self::new(base_url, application, mcs_run_env)
+        Some(Self::new(base_url, application, mcs_run_env))
     }
 }
 

--- a/lib/runtime-settings/src/secrets/resolver.rs
+++ b/lib/runtime-settings/src/secrets/resolver.rs
@@ -143,7 +143,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_secret_without_vault() {
         let secrets = SecretsService::new_without_vault();
-        let value = serde_json::json!({"password": {"$secret": "db/creds:password"}});
+        let value = serde_json::json!({"password": {"$secret": "secret/data/db/creds:password"}});
 
         let result = resolve_secrets(&value, &secrets).await;
         assert!(matches!(result, Err(SettingsError::SecretWithoutVault)));

--- a/lib/runtime-settings/src/settings.rs
+++ b/lib/runtime-settings/src/settings.rs
@@ -397,7 +397,7 @@ impl RuntimeSettingsBuilder {
                 self.environment
                     .get("RUNTIME_SETTINGS_BASE_URL")
                     .cloned()
-                    .unwrap_or_else(|| "http://master.runtime-settings.dev3.cian.ru".to_string())
+                    .unwrap_or_else(|| "http://localhost:8080".to_string())
             });
             providers.push(Box::new(McsProvider::new(
                 base_url,

--- a/lib/runtime-settings/src/setup.rs
+++ b/lib/runtime-settings/src/setup.rs
@@ -17,7 +17,7 @@ pub fn settings() -> &'static RuntimeSettings {
 
 /// Initialize global settings with builder
 pub async fn setup(builder: RuntimeSettingsBuilder) -> Result<(), SettingsError> {
-    let runtime_settings = builder.build();
+    let runtime_settings = builder.build()?;
     let refresh_interval = runtime_settings.refresh_interval;
     runtime_settings.init().await?;
 

--- a/lib/runtime-settings/tests/integration_vault.rs
+++ b/lib/runtime-settings/tests/integration_vault.rs
@@ -60,9 +60,9 @@ async fn test_vault_get_secret() {
     // Create SecretsService with that client
     let secrets_service = SecretsService::new(client);
 
-    // Verify get("database/credentials", "password") returns the value
+    // Verify get("secret/data/database/credentials", "password") returns the value
     let password = secrets_service
-        .get("database/credentials", "password")
+        .get("secret/data/database/credentials", "password")
         .await
         .expect("should get password");
 
@@ -70,7 +70,7 @@ async fn test_vault_get_secret() {
 
     // Also verify username
     let username = secrets_service
-        .get("database/credentials", "username")
+        .get("secret/data/database/credentials", "username")
         .await
         .expect("should get username");
 
@@ -99,7 +99,7 @@ async fn test_vault_secret_caching() {
 
     // First call - should hit the mock
     let value1 = secrets_service
-        .get("cached/secret", "api_key")
+        .get("secret/data/cached/secret", "api_key")
         .await
         .expect("should get value on first call");
 
@@ -107,7 +107,7 @@ async fn test_vault_secret_caching() {
 
     // Second call - should use cache (mock expects only 1 call)
     let value2 = secrets_service
-        .get("cached/secret", "api_key")
+        .get("secret/data/cached/secret", "api_key")
         .await
         .expect("should get value on second call from cache");
 
@@ -134,7 +134,7 @@ async fn test_vault_secret_not_found() {
     let secrets_service = SecretsService::new(client);
 
     // Verify get() returns error
-    let result = secrets_service.get("nonexistent/path", "key").await;
+    let result = secrets_service.get("secret/data/nonexistent/path", "key").await;
 
     assert!(result.is_err(), "should return error for 404");
     let err = result.unwrap_err();
@@ -167,7 +167,7 @@ async fn test_vault_key_not_found_in_secret() {
     let secrets_service = SecretsService::new(client);
 
     // Try to get non-existent key
-    let result = secrets_service.get("app/config", "nonexistent_key").await;
+    let result = secrets_service.get("secret/data/app/config", "nonexistent_key").await;
 
     // Verify get() returns error
     assert!(result.is_err(), "should return error for missing key");
@@ -191,7 +191,7 @@ async fn test_secrets_without_vault() {
     let secrets_service = SecretsService::new_without_vault();
 
     // Verify get() returns error
-    let result = secrets_service.get("any/path", "any_key").await;
+    let result = secrets_service.get("secret/data/any/path", "any_key").await;
 
     assert!(result.is_err(), "should return error without vault");
     let err = result.unwrap_err();

--- a/lib/vault-client/Cargo.toml
+++ b/lib/vault-client/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-trait = "0.1"
 vaultrs = "0.7"
 tokio = { version = "1", features = ["sync", "time", "rt", "net"] }
 serde = { version = "1", features = ["derive"] }

--- a/lib/vault-client/Cargo.toml
+++ b/lib/vault-client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vault-client"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+vaultrs = "0.7"
+tokio = { version = "1", features = ["sync", "time", "rt", "net"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+chrono = { version = "0.4", features = ["serde"] }
+directories = "5"
+sha2 = "0.10"
+webbrowser = "1"
+tracing = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+wiremock = "0.6"
+tempfile = "3"

--- a/lib/vault-client/src/auth/kubernetes.rs
+++ b/lib/vault-client/src/auth/kubernetes.rs
@@ -1,0 +1,131 @@
+use super::{AuthMethod, TokenInfo};
+use crate::VaultError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const DEFAULT_JWT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+/// Kubernetes authentication
+pub struct KubernetesAuth {
+    pub auth_method: String,
+    pub role: String,
+    pub jwt_path: String,
+}
+
+impl KubernetesAuth {
+    pub fn new(auth_method: String, role: String) -> Self {
+        Self {
+            auth_method,
+            role,
+            jwt_path: DEFAULT_JWT_PATH.to_string(),
+        }
+    }
+
+    pub fn with_jwt_path(mut self, path: String) -> Self {
+        self.jwt_path = path;
+        self
+    }
+
+    fn read_jwt(&self) -> Result<String, VaultError> {
+        std::fs::read_to_string(&self.jwt_path)
+            .map(|s| s.trim().to_string())
+            .map_err(|e| {
+                VaultError::KubernetesError(format!(
+                    "Failed to read JWT from {}: {}",
+                    self.jwt_path, e
+                ))
+            })
+    }
+}
+
+#[derive(Serialize)]
+struct LoginRequest {
+    jwt: String,
+    role: String,
+}
+
+#[derive(Deserialize)]
+struct LoginResponse {
+    auth: AuthData,
+}
+
+#[derive(Deserialize)]
+struct AuthData {
+    client_token: String,
+    lease_duration: u64,
+    renewable: bool,
+}
+
+#[async_trait]
+impl AuthMethod for KubernetesAuth {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError> {
+        let jwt = self.read_jwt()?;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/auth/{}/login", base_url, self.auth_method);
+
+        let response = client
+            .post(&url)
+            .json(&LoginRequest {
+                jwt,
+                role: self.role.clone(),
+            })
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        let login: LoginResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::AuthError(format!("Invalid response: {}", e)))?;
+
+        Ok(TokenInfo::new(
+            login.auth.client_token,
+            Duration::from_secs(login.auth.lease_duration),
+            login.auth.renewable,
+        ))
+    }
+
+    fn supports_renewal(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_jwt_from_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "my-jwt-token").unwrap();
+
+        let auth = KubernetesAuth::new("kubernetes".to_string(), "app".to_string())
+            .with_jwt_path(file.path().to_str().unwrap().to_string());
+
+        let jwt = auth.read_jwt().unwrap();
+        assert_eq!(jwt, "my-jwt-token");
+    }
+
+    #[test]
+    fn test_read_jwt_missing_file() {
+        let auth = KubernetesAuth::new("kubernetes".to_string(), "app".to_string())
+            .with_jwt_path("/nonexistent/path".to_string());
+
+        let result = auth.read_jwt();
+        assert!(matches!(result, Err(VaultError::KubernetesError(_))));
+    }
+}

--- a/lib/vault-client/src/auth/manager.rs
+++ b/lib/vault-client/src/auth/manager.rs
@@ -1,0 +1,199 @@
+use super::{AuthMethod, TokenInfo};
+use crate::VaultError;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+const DEFAULT_REFRESH_THRESHOLD: f64 = 0.75;
+const DEFAULT_MIN_RENEWAL_DURATION: Duration = Duration::from_secs(300);
+const DEFAULT_RETRY_INTERVAL: Duration = Duration::from_secs(10);
+
+pub struct TokenManagerConfig {
+    pub refresh_threshold: f64,
+    pub min_renewal_duration: Duration,
+    pub retry_interval: Duration,
+}
+
+impl Default for TokenManagerConfig {
+    fn default() -> Self {
+        Self {
+            refresh_threshold: DEFAULT_REFRESH_THRESHOLD,
+            min_renewal_duration: DEFAULT_MIN_RENEWAL_DURATION,
+            retry_interval: DEFAULT_RETRY_INTERVAL,
+        }
+    }
+}
+
+pub struct TokenManager {
+    base_url: String,
+    auth_method: Arc<dyn AuthMethod>,
+    token: Arc<RwLock<TokenInfo>>,
+    config: TokenManagerConfig,
+}
+
+impl TokenManager {
+    pub async fn new(
+        base_url: String,
+        auth_method: Arc<dyn AuthMethod>,
+        config: TokenManagerConfig,
+    ) -> Result<Self, VaultError> {
+        let token_info = auth_method.authenticate(&base_url).await?;
+
+        let manager = Self {
+            base_url,
+            auth_method,
+            token: Arc::new(RwLock::new(token_info)),
+            config,
+        };
+
+        manager.start_renewal_task();
+
+        Ok(manager)
+    }
+
+    pub async fn get_token(&self) -> String {
+        self.token.read().await.token.clone()
+    }
+
+    fn start_renewal_task(&self) {
+        let token = Arc::clone(&self.token);
+        let auth_method = Arc::clone(&self.auth_method);
+        let base_url = self.base_url.clone();
+        let config = TokenManagerConfig {
+            refresh_threshold: self.config.refresh_threshold,
+            min_renewal_duration: self.config.min_renewal_duration,
+            retry_interval: self.config.retry_interval,
+        };
+
+        tokio::spawn(async move {
+            loop {
+                let (needs_refresh, sleep_duration) = {
+                    let token_info = token.read().await;
+
+                    if token_info.lease_duration.is_zero() {
+                        // Static token, never refresh
+                        break;
+                    }
+
+                    if token_info.lease_duration < config.min_renewal_duration {
+                        // Token duration too short for renewal
+                        break;
+                    }
+
+                    let needs = token_info.needs_refresh(config.refresh_threshold);
+                    let until_refresh = if needs {
+                        Duration::ZERO
+                    } else {
+                        let threshold_time = Duration::from_secs_f64(
+                            token_info.lease_duration.as_secs_f64() * config.refresh_threshold,
+                        );
+                        threshold_time.saturating_sub(token_info.obtained_at.elapsed())
+                    };
+
+                    (needs, until_refresh)
+                };
+
+                if !needs_refresh {
+                    tokio::time::sleep(sleep_duration).await;
+                    continue;
+                }
+
+                // Try to renew
+                match Self::renew_token(&base_url, &token).await {
+                    Ok(()) => {
+                        tracing::debug!("Token renewed successfully");
+                    }
+                    Err(VaultError::ClientError { status, .. }) if status >= 400 && status < 500 => {
+                        // 4xx error - need to re-authenticate
+                        tracing::info!("Token renewal failed with 4xx, re-authenticating");
+                        match auth_method.authenticate(&base_url).await {
+                            Ok(new_token) => {
+                                let mut t = token.write().await;
+                                *t = new_token;
+                                tracing::debug!("Re-authenticated successfully");
+                            }
+                            Err(e) => {
+                                tracing::error!("Re-authentication failed: {}", e);
+                                tokio::time::sleep(config.retry_interval).await;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // 5xx or network error - retry later
+                        tracing::warn!("Token renewal failed: {}, retrying in {:?}", e, config.retry_interval);
+                        tokio::time::sleep(config.retry_interval).await;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn renew_token(base_url: &str, token: &Arc<RwLock<TokenInfo>>) -> Result<(), VaultError> {
+        let current_token = token.read().await.token.clone();
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/auth/token/renew-self", base_url);
+
+        let response = client
+            .post(&url)
+            .header("X-Vault-Token", &current_token)
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RenewResponse {
+            auth: AuthData,
+        }
+        #[derive(serde::Deserialize)]
+        struct AuthData {
+            client_token: String,
+            lease_duration: u64,
+            renewable: bool,
+        }
+
+        let resp: RenewResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::AuthError(format!("Invalid renewal response: {}", e)))?;
+
+        let mut t = token.write().await;
+        *t = TokenInfo::new(
+            resp.auth.client_token,
+            Duration::from_secs(resp.auth.lease_duration),
+            resp.auth.renewable,
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::StaticTokenAuth;
+
+    #[tokio::test]
+    async fn test_token_manager_with_static_token() {
+        let auth = Arc::new(StaticTokenAuth::new("my-token".to_string()));
+        let manager = TokenManager::new(
+            "http://vault:8200".to_string(),
+            auth,
+            TokenManagerConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(manager.get_token().await, "my-token");
+    }
+}

--- a/lib/vault-client/src/auth/mod.rs
+++ b/lib/vault-client/src/auth/mod.rs
@@ -1,10 +1,12 @@
 mod kubernetes;
+mod manager;
 mod oidc;
 mod oidc_cache;
 mod token;
 mod token_info;
 
 pub use kubernetes::KubernetesAuth;
+pub use manager::{TokenManager, TokenManagerConfig};
 pub use oidc::OidcAuth;
 pub use oidc_cache::OidcCache;
 pub use token::StaticTokenAuth;

--- a/lib/vault-client/src/auth/mod.rs
+++ b/lib/vault-client/src/auth/mod.rs
@@ -1,0 +1,16 @@
+mod token_info;
+
+pub use token_info::TokenInfo;
+
+use crate::VaultError;
+use async_trait::async_trait;
+
+/// Trait for authentication methods
+#[async_trait]
+pub trait AuthMethod: Send + Sync {
+    /// Perform initial authentication
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError>;
+
+    /// Whether this method supports token renewal via renew-self
+    fn supports_renewal(&self) -> bool;
+}

--- a/lib/vault-client/src/auth/mod.rs
+++ b/lib/vault-client/src/auth/mod.rs
@@ -1,9 +1,11 @@
 mod kubernetes;
+mod oidc;
 mod oidc_cache;
 mod token;
 mod token_info;
 
 pub use kubernetes::KubernetesAuth;
+pub use oidc::OidcAuth;
 pub use oidc_cache::OidcCache;
 pub use token::StaticTokenAuth;
 pub use token_info::TokenInfo;

--- a/lib/vault-client/src/auth/mod.rs
+++ b/lib/vault-client/src/auth/mod.rs
@@ -1,5 +1,7 @@
+mod token;
 mod token_info;
 
+pub use token::StaticTokenAuth;
 pub use token_info::TokenInfo;
 
 use crate::VaultError;

--- a/lib/vault-client/src/auth/mod.rs
+++ b/lib/vault-client/src/auth/mod.rs
@@ -1,8 +1,10 @@
 mod kubernetes;
+mod oidc_cache;
 mod token;
 mod token_info;
 
 pub use kubernetes::KubernetesAuth;
+pub use oidc_cache::OidcCache;
 pub use token::StaticTokenAuth;
 pub use token_info::TokenInfo;
 

--- a/lib/vault-client/src/auth/mod.rs
+++ b/lib/vault-client/src/auth/mod.rs
@@ -1,6 +1,8 @@
+mod kubernetes;
 mod token;
 mod token_info;
 
+pub use kubernetes::KubernetesAuth;
 pub use token::StaticTokenAuth;
 pub use token_info::TokenInfo;
 

--- a/lib/vault-client/src/auth/oidc.rs
+++ b/lib/vault-client/src/auth/oidc.rs
@@ -1,0 +1,224 @@
+use super::{AuthMethod, OidcCache, TokenInfo};
+use crate::VaultError;
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+const CALLBACK_PORT: u16 = 8250;
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
+
+/// OIDC authentication (for local development)
+pub struct OidcAuth {
+    pub auth_method: String,
+    pub role: String,
+    cache: Option<OidcCache>,
+}
+
+impl OidcAuth {
+    pub fn new(auth_method: String, role: String) -> Self {
+        Self {
+            auth_method,
+            role,
+            cache: OidcCache::new(),
+        }
+    }
+
+    async fn get_auth_url(&self, base_url: &str) -> Result<(String, String), VaultError> {
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/auth/{}/oidc/auth_url", base_url, self.auth_method);
+
+        let response = client
+            .post(&url)
+            .json(&serde_json::json!({
+                "role": self.role,
+                "redirect_uri": format!("http://localhost:{}/oidc/callback", CALLBACK_PORT)
+            }))
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(Deserialize)]
+        struct AuthUrlResponse {
+            data: AuthUrlData,
+        }
+        #[derive(Deserialize)]
+        struct AuthUrlData {
+            auth_url: String,
+            state: String,
+        }
+
+        let resp: AuthUrlResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::OidcError(format!("Invalid auth_url response: {}", e)))?;
+
+        Ok((resp.data.auth_url, resp.data.state))
+    }
+
+    async fn wait_for_callback(&self, expected_state: &str) -> Result<(String, String), VaultError> {
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", CALLBACK_PORT))
+            .await
+            .map_err(|e| VaultError::OidcError(format!("Failed to bind callback port: {}", e)))?;
+
+        let result = tokio::time::timeout(CALLBACK_TIMEOUT, async {
+            let (mut stream, _) = listener.accept().await?;
+
+            let mut reader = BufReader::new(&mut stream);
+            let mut request_line = String::new();
+            reader.read_line(&mut request_line).await?;
+
+            // Parse: GET /oidc/callback?state=...&code=... HTTP/1.1
+            let path = request_line
+                .split_whitespace()
+                .nth(1)
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid request"))?;
+
+            let query = path
+                .split('?')
+                .nth(1)
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "No query string"))?;
+
+            let mut state = None;
+            let mut code = None;
+
+            for pair in query.split('&') {
+                if let Some((key, value)) = pair.split_once('=') {
+                    match key {
+                        "state" => state = Some(value.to_string()),
+                        "code" => code = Some(value.to_string()),
+                        _ => {}
+                    }
+                }
+            }
+
+            // Send response
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><body><h1>Authentication successful!</h1><p>You can close this window.</p></body></html>";
+            stream.write_all(response.as_bytes()).await?;
+
+            Ok::<_, std::io::Error>((
+                state.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Missing state"))?,
+                code.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Missing code"))?,
+            ))
+        })
+        .await
+        .map_err(|_| VaultError::OidcError("Callback timeout".to_string()))?
+        .map_err(|e| VaultError::OidcError(format!("Callback error: {}", e)))?;
+
+        let (state, code) = result;
+        if state != expected_state {
+            return Err(VaultError::OidcError("State mismatch".to_string()));
+        }
+
+        Ok((state, code))
+    }
+
+    async fn exchange_code(
+        &self,
+        base_url: &str,
+        state: &str,
+        code: &str,
+    ) -> Result<TokenInfo, VaultError> {
+        let client = reqwest::Client::new();
+        let url = format!(
+            "{}/v1/auth/{}/oidc/callback?state={}&code={}",
+            base_url, self.auth_method, state, code
+        );
+
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(Deserialize)]
+        struct CallbackResponse {
+            auth: AuthData,
+        }
+        #[derive(Deserialize)]
+        struct AuthData {
+            client_token: String,
+            lease_duration: u64,
+            renewable: bool,
+        }
+
+        let resp: CallbackResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::OidcError(format!("Invalid callback response: {}", e)))?;
+
+        Ok(TokenInfo::new(
+            resp.auth.client_token,
+            Duration::from_secs(resp.auth.lease_duration),
+            resp.auth.renewable,
+        ))
+    }
+}
+
+#[async_trait]
+impl AuthMethod for OidcAuth {
+    async fn authenticate(&self, base_url: &str) -> Result<TokenInfo, VaultError> {
+        // Check cache first
+        if let Some(ref cache) = self.cache {
+            if let Some(token) = cache.get(base_url, &self.auth_method, &self.role) {
+                tracing::debug!("Using cached OIDC token");
+                return Ok(TokenInfo::static_token(token));
+            }
+        }
+
+        // Get auth URL
+        let (auth_url, state) = self.get_auth_url(base_url).await?;
+
+        // Open browser
+        tracing::info!("Opening browser for OIDC authentication...");
+        if webbrowser::open(&auth_url).is_err() {
+            tracing::warn!("Failed to open browser. Please visit: {}", auth_url);
+        }
+
+        // Wait for callback
+        let (state, code) = self.wait_for_callback(&state).await?;
+
+        // Exchange code for token
+        let token_info = self.exchange_code(base_url, &state, &code).await?;
+
+        // Cache token
+        if let Some(ref cache) = self.cache {
+            if let Err(e) = cache.set(
+                base_url,
+                &self.auth_method,
+                &self.role,
+                &token_info.token,
+                token_info.lease_duration,
+            ) {
+                tracing::warn!("Failed to cache OIDC token: {}", e);
+            }
+        }
+
+        Ok(token_info)
+    }
+
+    fn supports_renewal(&self) -> bool {
+        true
+    }
+}

--- a/lib/vault-client/src/auth/oidc_cache.rs
+++ b/lib/vault-client/src/auth/oidc_cache.rs
@@ -1,0 +1,160 @@
+use crate::VaultError;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const MIN_REMAINING_TTL: Duration = Duration::from_secs(3600); // 1 hour
+
+#[derive(Serialize, Deserialize)]
+struct CachedToken {
+    token: String,
+    expires_at: u64, // Unix timestamp
+}
+
+pub struct OidcCache {
+    cache_dir: PathBuf,
+}
+
+impl OidcCache {
+    pub fn new() -> Option<Self> {
+        directories::ProjectDirs::from("", "", "vault-client")
+            .map(|dirs| Self {
+                cache_dir: dirs.cache_dir().to_path_buf(),
+            })
+    }
+
+    fn cache_key(vault_addr: &str, auth_method: &str, role: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(vault_addr);
+        hasher.update(auth_method);
+        hasher.update(role);
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn cache_path(&self, vault_addr: &str, auth_method: &str, role: &str) -> PathBuf {
+        let key = Self::cache_key(vault_addr, auth_method, role);
+        self.cache_dir.join(format!("{}.json", key))
+    }
+
+    /// Get cached token if valid for at least MIN_REMAINING_TTL
+    pub fn get(&self, vault_addr: &str, auth_method: &str, role: &str) -> Option<String> {
+        let path = self.cache_path(vault_addr, auth_method, role);
+        let content = std::fs::read_to_string(&path).ok()?;
+        let cached: CachedToken = serde_json::from_str(&content).ok()?;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let remaining = cached.expires_at.saturating_sub(now);
+        if remaining >= MIN_REMAINING_TTL.as_secs() {
+            Some(cached.token)
+        } else {
+            None
+        }
+    }
+
+    /// Store token with expiration
+    pub fn set(
+        &self,
+        vault_addr: &str,
+        auth_method: &str,
+        role: &str,
+        token: &str,
+        ttl: Duration,
+    ) -> Result<(), VaultError> {
+        std::fs::create_dir_all(&self.cache_dir)?;
+
+        let expires_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + ttl.as_secs();
+
+        let cached = CachedToken {
+            token: token.to_string(),
+            expires_at,
+        };
+
+        let path = self.cache_path(vault_addr, auth_method, role);
+        let content = serde_json::to_string(&cached)?;
+        std::fs::write(&path, content)?;
+
+        Ok(())
+    }
+
+    /// Clear cached token
+    pub fn clear(&self, vault_addr: &str, auth_method: &str, role: &str) {
+        let path = self.cache_path(vault_addr, auth_method, role);
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cache_with_temp_dir() -> (OidcCache, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let cache = OidcCache {
+            cache_dir: dir.path().to_path_buf(),
+        };
+        (cache, dir)
+    }
+
+    #[test]
+    fn test_cache_key_is_deterministic() {
+        let key1 = OidcCache::cache_key("http://vault:8200", "oidc", "dev");
+        let key2 = OidcCache::cache_key("http://vault:8200", "oidc", "dev");
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_cache_key_differs_for_different_inputs() {
+        let key1 = OidcCache::cache_key("http://vault:8200", "oidc", "dev");
+        let key2 = OidcCache::cache_key("http://vault:8200", "oidc", "prod");
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn test_set_and_get_token() {
+        let (cache, _dir) = cache_with_temp_dir();
+
+        cache
+            .set("http://vault:8200", "oidc", "dev", "my-token", Duration::from_secs(7200))
+            .unwrap();
+
+        let token = cache.get("http://vault:8200", "oidc", "dev");
+        assert_eq!(token, Some("my-token".to_string()));
+    }
+
+    #[test]
+    fn test_expired_token_not_returned() {
+        let (cache, _dir) = cache_with_temp_dir();
+
+        // Set token with 0 TTL (already expired)
+        cache
+            .set("http://vault:8200", "oidc", "dev", "expired", Duration::ZERO)
+            .unwrap();
+
+        let token = cache.get("http://vault:8200", "oidc", "dev");
+        assert!(token.is_none());
+    }
+
+    #[test]
+    fn test_clear_removes_token() {
+        let (cache, _dir) = cache_with_temp_dir();
+
+        cache
+            .set("http://vault:8200", "oidc", "dev", "my-token", Duration::from_secs(7200))
+            .unwrap();
+
+        cache.clear("http://vault:8200", "oidc", "dev");
+
+        let token = cache.get("http://vault:8200", "oidc", "dev");
+        assert!(token.is_none());
+    }
+}

--- a/lib/vault-client/src/auth/token.rs
+++ b/lib/vault-client/src/auth/token.rs
@@ -1,0 +1,38 @@
+use super::{AuthMethod, TokenInfo};
+use crate::VaultError;
+use async_trait::async_trait;
+
+/// Static token authentication
+pub struct StaticTokenAuth {
+    token: String,
+}
+
+impl StaticTokenAuth {
+    pub fn new(token: String) -> Self {
+        Self { token }
+    }
+}
+
+#[async_trait]
+impl AuthMethod for StaticTokenAuth {
+    async fn authenticate(&self, _base_url: &str) -> Result<TokenInfo, VaultError> {
+        Ok(TokenInfo::static_token(self.token.clone()))
+    }
+
+    fn supports_renewal(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_static_token_auth() {
+        let auth = StaticTokenAuth::new("my-token".to_string());
+        let token_info = auth.authenticate("http://vault:8200").await.unwrap();
+        assert_eq!(token_info.token, "my-token");
+        assert!(!auth.supports_renewal());
+    }
+}

--- a/lib/vault-client/src/auth/token_info.rs
+++ b/lib/vault-client/src/auth/token_info.rs
@@ -1,0 +1,76 @@
+use std::time::{Duration, Instant};
+
+/// Token information from authentication
+#[derive(Debug, Clone)]
+pub struct TokenInfo {
+    pub token: String,
+    pub lease_duration: Duration,
+    pub renewable: bool,
+    pub obtained_at: Instant,
+}
+
+impl TokenInfo {
+    pub fn new(token: String, lease_duration: Duration, renewable: bool) -> Self {
+        Self {
+            token,
+            lease_duration,
+            renewable,
+            obtained_at: Instant::now(),
+        }
+    }
+
+    /// Static token (never expires)
+    pub fn static_token(token: String) -> Self {
+        Self {
+            token,
+            lease_duration: Duration::ZERO,
+            renewable: false,
+            obtained_at: Instant::now(),
+        }
+    }
+
+    /// Check if token needs refresh (at threshold % of lease)
+    pub fn needs_refresh(&self, threshold: f64) -> bool {
+        if self.lease_duration.is_zero() {
+            return false; // Static token
+        }
+        let elapsed = self.obtained_at.elapsed();
+        let threshold_duration = Duration::from_secs_f64(self.lease_duration.as_secs_f64() * threshold);
+        elapsed >= threshold_duration
+    }
+
+    /// Check if token is expired
+    pub fn is_expired(&self) -> bool {
+        if self.lease_duration.is_zero() {
+            return false;
+        }
+        self.obtained_at.elapsed() >= self.lease_duration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_static_token_never_expires() {
+        let token = TokenInfo::static_token("test".to_string());
+        assert!(!token.needs_refresh(0.75));
+        assert!(!token.is_expired());
+    }
+
+    #[test]
+    fn test_token_needs_refresh_at_threshold() {
+        let mut token = TokenInfo::new("test".to_string(), Duration::from_secs(100), true);
+        // Simulate time passing
+        token.obtained_at = Instant::now() - Duration::from_secs(80);
+        assert!(token.needs_refresh(0.75));
+    }
+
+    #[test]
+    fn test_token_not_expired_before_lease() {
+        let mut token = TokenInfo::new("test".to_string(), Duration::from_secs(100), true);
+        token.obtained_at = Instant::now() - Duration::from_secs(50);
+        assert!(!token.is_expired());
+    }
+}

--- a/lib/vault-client/src/client.rs
+++ b/lib/vault-client/src/client.rs
@@ -1,0 +1,383 @@
+use crate::auth::{
+    AuthMethod, KubernetesAuth, OidcAuth, StaticTokenAuth, TokenManager, TokenManagerConfig,
+};
+use crate::error::VaultError;
+use crate::models::{KvData, KvMetadata, KvVersion};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+const DEFAULT_K8S_AUTH_METHOD: &str = "kubernetes";
+const DEFAULT_OIDC_AUTH_METHOD: &str = "oidc";
+const DEFAULT_ROLE: &str = "app";
+
+pub struct VaultClientBuilder {
+    base_url: Option<String>,
+    token: Option<String>,
+    k8s_auth_method: Option<String>,
+    oidc_auth_method: Option<String>,
+    role: Option<String>,
+    application_name: Option<String>,
+    renewable_token_min_duration: Duration,
+    retry_interval: Duration,
+}
+
+impl Default for VaultClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VaultClientBuilder {
+    pub fn new() -> Self {
+        Self {
+            base_url: None,
+            token: None,
+            k8s_auth_method: None,
+            oidc_auth_method: None,
+            role: None,
+            application_name: None,
+            renewable_token_min_duration: Duration::from_secs(300),
+            retry_interval: Duration::from_secs(10),
+        }
+    }
+
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        self.token = Some(token.into());
+        self
+    }
+
+    pub fn k8s_auth_method(mut self, method: impl Into<String>) -> Self {
+        self.k8s_auth_method = Some(method.into());
+        self
+    }
+
+    pub fn oidc_auth_method(mut self, method: impl Into<String>) -> Self {
+        self.oidc_auth_method = Some(method.into());
+        self
+    }
+
+    pub fn role(mut self, role: impl Into<String>) -> Self {
+        self.role = Some(role.into());
+        self
+    }
+
+    pub fn application_name(mut self, name: impl Into<String>) -> Self {
+        self.application_name = Some(name.into());
+        self
+    }
+
+    pub fn renewable_token_min_duration(mut self, duration: Duration) -> Self {
+        self.renewable_token_min_duration = duration;
+        self
+    }
+
+    pub fn retry_interval(mut self, duration: Duration) -> Self {
+        self.retry_interval = duration;
+        self
+    }
+
+    fn resolve_config(&self) -> Result<ResolvedConfig, VaultError> {
+        let base_url = self
+            .base_url
+            .clone()
+            .or_else(|| std::env::var("VAULT_ADDR").ok())
+            .ok_or(VaultError::VaultNotDetected)?;
+
+        let token = self
+            .token
+            .clone()
+            .or_else(|| std::env::var("VAULT_TOKEN").ok());
+
+        let k8s_auth_method = self
+            .k8s_auth_method
+            .clone()
+            .or_else(|| std::env::var("VAULT_AUTH_METHOD").ok())
+            .unwrap_or_else(|| DEFAULT_K8S_AUTH_METHOD.to_string());
+
+        let oidc_auth_method = self
+            .oidc_auth_method
+            .clone()
+            .unwrap_or_else(|| DEFAULT_OIDC_AUTH_METHOD.to_string());
+
+        let role = self
+            .role
+            .clone()
+            .or_else(|| std::env::var("VAULT_ROLE_ID").ok())
+            .unwrap_or_else(|| DEFAULT_ROLE.to_string());
+
+        let k8s_jwt_path = std::env::var("K8S_JWT_TOKEN_PATH")
+            .unwrap_or_else(|_| "/var/run/secrets/kubernetes.io/serviceaccount/token".to_string());
+
+        let is_kubernetes = std::env::var("KUBERNETES_SERVICE_HOST").is_ok();
+
+        Ok(ResolvedConfig {
+            base_url,
+            token,
+            k8s_auth_method,
+            oidc_auth_method,
+            role,
+            k8s_jwt_path,
+            is_kubernetes,
+            application_name: self.application_name.clone(),
+            renewable_token_min_duration: self.renewable_token_min_duration,
+            retry_interval: self.retry_interval,
+        })
+    }
+
+    pub async fn build(self) -> Result<VaultClient, VaultError> {
+        let config = self.resolve_config()?;
+
+        let auth_method: Arc<dyn AuthMethod> = if let Some(token) = config.token {
+            Arc::new(StaticTokenAuth::new(token))
+        } else if config.is_kubernetes {
+            Arc::new(
+                KubernetesAuth::new(config.k8s_auth_method, config.role)
+                    .with_jwt_path(config.k8s_jwt_path),
+            )
+        } else {
+            Arc::new(OidcAuth::new(config.oidc_auth_method, config.role))
+        };
+
+        let token_manager = TokenManager::new(
+            config.base_url.clone(),
+            auth_method,
+            TokenManagerConfig {
+                refresh_threshold: 0.75,
+                min_renewal_duration: config.renewable_token_min_duration,
+                retry_interval: config.retry_interval,
+            },
+        )
+        .await?;
+
+        Ok(VaultClient {
+            base_url: config.base_url,
+            token_manager,
+            application_name: config.application_name,
+        })
+    }
+}
+
+struct ResolvedConfig {
+    base_url: String,
+    token: Option<String>,
+    k8s_auth_method: String,
+    oidc_auth_method: String,
+    role: String,
+    k8s_jwt_path: String,
+    is_kubernetes: bool,
+    application_name: Option<String>,
+    renewable_token_min_duration: Duration,
+    retry_interval: Duration,
+}
+
+pub struct VaultClient {
+    base_url: String,
+    token_manager: TokenManager,
+    application_name: Option<String>,
+}
+
+impl VaultClient {
+    pub async fn from_env() -> Result<Self, VaultError> {
+        VaultClientBuilder::new().build().await
+    }
+
+    pub fn builder() -> VaultClientBuilder {
+        VaultClientBuilder::new()
+    }
+
+    pub async fn kv_read(&self, mount: &str, path: &str) -> Result<KvData, VaultError> {
+        let url = format!("{}/v1/{}/data/{}", self.base_url, mount, path);
+        let token = self.token_manager.get_token().await;
+
+        let client = reqwest::Client::new();
+        let mut request = client.get(&url).header("X-Vault-Token", token);
+
+        if let Some(ref app_name) = self.application_name {
+            request = request.header("User-Agent", app_name);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if response.status().as_u16() == 404 {
+            return Err(VaultError::SecretNotFound {
+                path: path.to_string(),
+            });
+        }
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(serde::Deserialize)]
+        struct KvResponse {
+            data: KvResponseData,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct KvResponseData {
+            data: HashMap<String, serde_json::Value>,
+            metadata: KvVersionResponse,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct KvVersionResponse {
+            version: u64,
+            created_time: String,
+            deletion_time: Option<String>,
+            #[serde(default)]
+            destroyed: bool,
+        }
+
+        let resp: KvResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::RequestError(format!("Invalid response: {}", e)))?;
+
+        Ok(KvData {
+            data: resp.data.data,
+            metadata: KvVersion {
+                version: resp.data.metadata.version,
+                created_time: resp
+                    .data
+                    .metadata
+                    .created_time
+                    .parse()
+                    .map_err(|e| VaultError::RequestError(format!("Invalid timestamp: {}", e)))?,
+                deletion_time: resp
+                    .data
+                    .metadata
+                    .deletion_time
+                    .and_then(|s| s.parse().ok()),
+                destroyed: resp.data.metadata.destroyed,
+            },
+        })
+    }
+
+    pub async fn kv_metadata(&self, mount: &str, path: &str) -> Result<KvMetadata, VaultError> {
+        let url = format!("{}/v1/{}/metadata/{}", self.base_url, mount, path);
+        let token = self.token_manager.get_token().await;
+
+        let client = reqwest::Client::new();
+        let mut request = client.get(&url).header("X-Vault-Token", token);
+
+        if let Some(ref app_name) = self.application_name {
+            request = request.header("User-Agent", app_name);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| VaultError::RequestError(e.to_string()))?;
+
+        if response.status().as_u16() == 404 {
+            return Err(VaultError::SecretNotFound {
+                path: path.to_string(),
+            });
+        }
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VaultError::ClientError {
+                status,
+                message: body,
+                response_data: None,
+            });
+        }
+
+        #[derive(serde::Deserialize)]
+        struct MetadataResponse {
+            data: MetadataData,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct MetadataData {
+            created_time: String,
+            custom_metadata: Option<HashMap<String, String>>,
+            versions: HashMap<String, VersionInfo>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct VersionInfo {
+            created_time: String,
+            deletion_time: Option<String>,
+            #[serde(default)]
+            destroyed: bool,
+        }
+
+        let resp: MetadataResponse = response
+            .json()
+            .await
+            .map_err(|e| VaultError::RequestError(format!("Invalid response: {}", e)))?;
+
+        let mut versions: Vec<KvVersion> = resp
+            .data
+            .versions
+            .into_iter()
+            .map(|(version_str, info)| {
+                Ok(KvVersion {
+                    version: version_str
+                        .parse()
+                        .map_err(|_| VaultError::RequestError("Invalid version".to_string()))?,
+                    created_time: info
+                        .created_time
+                        .parse()
+                        .map_err(|e| VaultError::RequestError(format!("Invalid timestamp: {}", e)))?,
+                    deletion_time: info.deletion_time.and_then(|s| s.parse().ok()),
+                    destroyed: info.destroyed,
+                })
+            })
+            .collect::<Result<Vec<_>, VaultError>>()?;
+
+        versions.sort_by_key(|v| v.version);
+
+        Ok(KvMetadata {
+            created_time: resp
+                .data
+                .created_time
+                .parse()
+                .map_err(|e| VaultError::RequestError(format!("Invalid timestamp: {}", e)))?,
+            custom_metadata: resp.data.custom_metadata,
+            versions,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_defaults() {
+        let builder = VaultClientBuilder::new();
+        assert!(builder.base_url.is_none());
+        assert!(builder.token.is_none());
+    }
+
+    #[test]
+    fn test_builder_chain() {
+        let builder = VaultClientBuilder::new()
+            .base_url("http://vault:8200")
+            .token("my-token")
+            .role("admin");
+
+        assert_eq!(builder.base_url, Some("http://vault:8200".to_string()));
+        assert_eq!(builder.token, Some("my-token".to_string()));
+        assert_eq!(builder.role, Some("admin".to_string()));
+    }
+}

--- a/lib/vault-client/src/error.rs
+++ b/lib/vault-client/src/error.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VaultError {
+    #[error("Vault not detected: VAULT_ADDR not set")]
+    VaultNotDetected,
+
+    #[error("Secret not found: {path}")]
+    SecretNotFound { path: String },
+
+    #[error("Vault client error ({status}): {message}")]
+    ClientError {
+        status: u16,
+        message: String,
+        response_data: Option<serde_json::Value>,
+    },
+
+    #[error("Vault request error: {0}")]
+    RequestError(String),
+
+    #[error("Authentication failed: {0}")]
+    AuthError(String),
+
+    #[error("OIDC authentication failed: {0}")]
+    OidcError(String),
+
+    #[error("Kubernetes auth failed: {0}")]
+    KubernetesError(String),
+
+    #[error("Token expired and renewal failed")]
+    TokenExpired,
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/lib/vault-client/src/lib.rs
+++ b/lib/vault-client/src/lib.rs
@@ -9,4 +9,3 @@ mod error;
 mod models;
 
 pub use error::VaultError;
-pub use models::{KvData, KvMetadata, KvVersion};

--- a/lib/vault-client/src/lib.rs
+++ b/lib/vault-client/src/lib.rs
@@ -9,3 +9,4 @@ mod error;
 mod models;
 
 pub use error::VaultError;
+pub use models::{KvData, KvMetadata, KvVersion};

--- a/lib/vault-client/src/lib.rs
+++ b/lib/vault-client/src/lib.rs
@@ -1,0 +1,12 @@
+//! vault-client - Rust client for HashiCorp Vault
+//!
+//! Auto-detects authentication method:
+//! 1. VAULT_TOKEN → static token
+//! 2. KUBERNETES_SERVICE_HOST → K8s auth
+//! 3. Otherwise → OIDC (local development)
+
+mod error;
+mod models;
+
+pub use error::VaultError;
+pub use models::{KvData, KvMetadata, KvVersion};

--- a/lib/vault-client/src/lib.rs
+++ b/lib/vault-client/src/lib.rs
@@ -4,11 +4,25 @@
 //! 1. VAULT_TOKEN → static token
 //! 2. KUBERNETES_SERVICE_HOST → K8s auth
 //! 3. Otherwise → OIDC (local development)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vault_client::VaultClient;
+//!
+//! let client = VaultClient::from_env().await?;
+//! let secret = client.kv_read("secret", "my/path").await?;
+//! println!("{:?}", secret.data);
+//! ```
 
 mod auth;
+mod client;
 mod error;
 mod models;
 
-pub use auth::TokenInfo;
+pub use client::{VaultClient, VaultClientBuilder};
 pub use error::VaultError;
 pub use models::{KvData, KvMetadata, KvVersion};
+
+// Re-export for advanced usage
+pub use auth::TokenInfo;

--- a/lib/vault-client/src/lib.rs
+++ b/lib/vault-client/src/lib.rs
@@ -5,8 +5,10 @@
 //! 2. KUBERNETES_SERVICE_HOST → K8s auth
 //! 3. Otherwise → OIDC (local development)
 
+mod auth;
 mod error;
 mod models;
 
+pub use auth::TokenInfo;
 pub use error::VaultError;
 pub use models::{KvData, KvMetadata, KvVersion};

--- a/lib/vault-client/src/models.rs
+++ b/lib/vault-client/src/models.rs
@@ -1,0 +1,62 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// KV v2 secret data with version metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvData {
+    pub data: HashMap<String, serde_json::Value>,
+    pub metadata: KvVersion,
+}
+
+/// Version information for a secret
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvVersion {
+    pub version: u64,
+    pub created_time: DateTime<Utc>,
+    #[serde(default)]
+    pub deletion_time: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub destroyed: bool,
+}
+
+/// Full metadata for a secret including all versions
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvMetadata {
+    pub created_time: DateTime<Utc>,
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String, String>>,
+    pub versions: Vec<KvVersion>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kv_data_deserialize() {
+        let json = r#"{
+            "data": {"username": "admin", "password": "secret"},
+            "metadata": {
+                "version": 1,
+                "created_time": "2024-01-01T00:00:00Z",
+                "destroyed": false
+            }
+        }"#;
+        let data: KvData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.metadata.version, 1);
+        assert_eq!(data.data.get("username").unwrap(), "admin");
+    }
+
+    #[test]
+    fn test_kv_version_optional_fields() {
+        let json = r#"{
+            "version": 2,
+            "created_time": "2024-01-01T00:00:00Z"
+        }"#;
+        let version: KvVersion = serde_json::from_str(json).unwrap();
+        assert_eq!(version.version, 2);
+        assert!(version.deletion_time.is_none());
+        assert!(!version.destroyed);
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `vault-client` library with auto-detection of auth method (Token → K8s → OIDC)
- Implement background token renewal using tokio task
- Add OIDC disk cache for token persistence
- Integrate vault-client into runtime-settings (replaces direct vaultrs usage)

## Test plan
- [x] Unit tests for all auth methods
- [x] Unit tests for TokenManager
- [x] Unit tests for OIDC cache
- [x] Integration tests with runtime-settings